### PR TITLE
Sanitize Shopify domain

### DIFF
--- a/src/lib/shopify.ts
+++ b/src/lib/shopify.ts
@@ -1,4 +1,5 @@
-const domain = process.env.SHOPIFY_STORE_DOMAIN!;
+const domain =
+  process.env.SHOPIFY_STORE_DOMAIN?.replace(/^https?:\/\//, '') || '';
 const token = process.env.SHOPIFY_STOREFRONT_TOKEN!;
 
 export async function shopifyFetch({ query, variables = {} }: { query: string; variables?: any }) {

--- a/src/pages/api/cart/add.ts
+++ b/src/pages/api/cart/add.ts
@@ -1,6 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const domain =
+    process.env.SHOPIFY_STORE_DOMAIN?.replace(/^https?:\/\//, '') || '';
   const { cartId, lines } = JSON.parse(req.body);
 
   const query = `
@@ -35,14 +37,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const variables = { cartId, lines };
 
-  const response = await fetch(process.env.SHOPIFY_STORE_DOMAIN + '/api/2023-01/graphql.json', {
-    method: 'POST',
-    headers: {
-      'X-Shopify-Storefront-Access-Token': process.env.SHOPIFY_STOREFRONT_TOKEN!,
-      'Content-Type': 'application/json',
+  const response = await fetch(
+    `https://${domain}/api/2023-01/graphql.json`,
+    {
+      method: 'POST',
+      headers: {
+        'X-Shopify-Storefront-Access-Token': process.env.SHOPIFY_STOREFRONT_TOKEN!,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query, variables }),
     },
-    body: JSON.stringify({ query, variables }),
-  });
+  );
 
   const json = await response.json();
   res.status(200).json(json.data.cartLinesAdd.cart);

--- a/src/pages/api/cart/create.ts
+++ b/src/pages/api/cart/create.ts
@@ -1,6 +1,8 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(_: NextApiRequest, res: NextApiResponse) {
+  const domain =
+    process.env.SHOPIFY_STORE_DOMAIN?.replace(/^https?:\/\//, '') || '';
   const query = `
     mutation {
       cartCreate {
@@ -11,14 +13,17 @@ export default async function handler(_: NextApiRequest, res: NextApiResponse) {
     }
   `;
 
-  const response = await fetch(process.env.SHOPIFY_STORE_DOMAIN + '/api/2023-01/graphql.json', {
-    method: 'POST',
-    headers: {
-      'X-Shopify-Storefront-Access-Token': process.env.SHOPIFY_STOREFRONT_TOKEN!,
-      'Content-Type': 'application/json',
+  const response = await fetch(
+    `https://${domain}/api/2023-01/graphql.json`,
+    {
+      method: 'POST',
+      headers: {
+        'X-Shopify-Storefront-Access-Token': process.env.SHOPIFY_STOREFRONT_TOKEN!,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query }),
     },
-    body: JSON.stringify({ query }),
-  });
+  );
 
   const json = await response.json();
   res.status(200).json(json.data.cartCreate.cart);


### PR DESCRIPTION
## Summary
- sanitize `SHOPIFY_STORE_DOMAIN` before building Shopify URLs
- apply the same URL sanitizing logic in cart API handlers

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3e88d7908328a3ab97dd45539bb0