### PR TITLE
Update favourites page layout

### DIFF
--- a/src/pages/favourites.tsx
+++ b/src/pages/favourites.tsx
@@ -10,19 +10,19 @@ export default function FavouritesPage() {
     <>
       <Seo title="My Favourites | AURICLE" />
 
-      <div className="collection-page">
-        <div className="filters-desktop" /> {/* Empty sidebar to preserve layout */}
+      <div style={{ maxWidth: '1400px', margin: '0 auto', padding: '16px 16px 0' }}>
+        <h1 style={{ fontSize: '30px', fontWeight: 900 }}>My Favourites</h1>
+        {favourites.length === 0 && (
+          <p style={{ fontSize: '14px', marginTop: '8px' }}>
+            You haven’t added any favourites yet.
+          </p>
+        )}
+      </div>
+
+      <main className="collection-page">
+        <aside className="filters-desktop" /> {/* Empty sidebar to preserve layout */}
 
         <section className="product-grid">
-          <div style={{ gridColumn: '1 / -1', marginBottom: '16px' }}>
-            <h1 style={{ fontSize: '30px', fontWeight: 900 }}>My Favourites</h1>
-            {favourites.length === 0 && (
-              <p style={{ fontSize: '14px', marginTop: '8px' }}>
-                You haven’t added any favourites yet.
-              </p>
-            )}
-          </div>
-
           {favourites.map((item) => (
             <Link href={`/product/${item.id}`} key={item.id} className="product-card">
               <div className="product-card-inner">
@@ -32,6 +32,8 @@ export default function FavouritesPage() {
                     alt={item.title}
                     width={1200}
                     height={1500}
+                    style={{ objectFit: 'cover', width: '100%', height: 'auto', display: 'block' }}
+                    sizes="(min-width: 1400px) 350px, (min-width: 1024px) 25vw, (min-width: 768px) 50vw, 100vw"
                   />
                 </div>
 
@@ -46,7 +48,7 @@ export default function FavouritesPage() {
             </Link>
           ))}
         </section>
-      </div>
+      </main>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- wrap favourites layout in container div and switch outer div to main
- move header content above the grid
- add responsive props to favourites page product images

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e62cd59808328ba4130abf84cc20c