### PR TITLE
Use Next.js Link in footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Link from 'next/link';
 
 const sections = [
   {
@@ -62,7 +63,11 @@ export default function Footer() {
         <ul className="footer-links">
           {section.links.map((link) => (
             <li key={link.href}>
-              <a href={link.href}>{link.label}</a>
+              {link.href.startsWith('/') ? (
+                <Link href={link.href}>{link.label}</Link>
+              ) : (
+                <a href={link.href}>{link.label}</a>
+              )}
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- switch internal footer links to use `<Link>` for Next.js navigation

## Testing
- `npm install` *(fails: network access blocked)*
- `npm run lint` *(fails: `next` not found without dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687f88cf1c288328957fca8f8ea0d438