### PR TITLE
Add scroll reset on route change

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,7 @@
 import type { AppProps } from 'next/app';
 import Head from 'next/head'; // ✅ Add this
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 import '@/styles/globals.css';
 import '@/styles/pages/home.scss';
 import '@/styles/pages/footer.scss';
@@ -20,6 +22,22 @@ import CartDrawer from '@/components/CartDrawer';
 import { FavouritesProvider } from '@/context/FavouritesContext';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleRouteChange = () => {
+      if (typeof window !== 'undefined') {
+        window.scrollTo(0, 0);
+      }
+    };
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [router.events]);
+
   return (
     <AuthProvider>
       <FavouritesProvider>


### PR DESCRIPTION
## Summary
- call `window.scrollTo(0,0)` on every route change

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8b017d148328b838441de73512f6