### PR TITLE
Use next/link for studio claim button

### DIFF
--- a/src/pages/piercing/[area]/[company].tsx
+++ b/src/pages/piercing/[area]/[company].tsx
@@ -1,4 +1,5 @@
 import { GetServerSideProps } from 'next';
+import Link from 'next/link';
 import { supabase } from '@/lib/supabase';
 
 interface Studio {
@@ -81,7 +82,9 @@ export default function StudioPage({ studio }: { studio: Studio }) {
 
         <div className="studio-claim">
           <p>Own this studio?</p>
-          <a href="/contact" className="claim-button">Claim this listing</a>
+          <Link href="/contact" className="claim-button">
+            Claim this listing
+          </Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- import `Link` in studio page for piercing companies
- replace `<a>` claim button with `next/link` component

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8fd7c94083288369481686205adc