### PR TITLE
Fix scroll restoration

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -25,6 +25,12 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
 
   useEffect(() => {
+    if (typeof window !== 'undefined' && 'scrollRestoration' in window.history) {
+      window.history.scrollRestoration = 'manual';
+    }
+  }, []);
+
+  useEffect(() => {
     const handleRouteChange = () => {
       if (typeof window !== 'undefined') {
         window.scrollTo(0, 0);


### PR DESCRIPTION
## Summary
- prevent the browser from restoring scroll position on reload by updating `_app.tsx`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f90f0467483289d828d751ebfd3e7