### PR TITLE
Fix viewport units

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -60,7 +60,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           <meta name="msapplication-TileColor" content="#ffffff" />
           <meta name="theme-color" content="#ffffff" />
         </Head>
-        <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100dvh' }}>
   <Header />
   <main style={{ flex: '1 0 auto' }}>
     <Component {...pageProps} />

--- a/src/styles/pages/CartDrawer.scss
+++ b/src/styles/pages/CartDrawer.scss
@@ -3,7 +3,8 @@
   top: 0;
   right: -100%;
   width: 320px;
-  height: 100vh;
+  height: 100vh; // fallback for browsers without dvh support
+  height: 100dvh;
   background: #fff;
   box-shadow: -4px 0 12px rgba(0, 0, 0, 0.05);
   z-index: 1000;


### PR DESCRIPTION
## Summary
- use `minHeight: 100dvh` for the global layout container
- allow cart drawer to adapt to dynamic viewport height with dvh fallback

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68809a7d3fc4832889b88983aa502440