### PR TITLE
Fix background scroll blocking for cart drawer

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -37,7 +37,7 @@ export default function CartDrawer() {
   if (!isDrawerOpen) return null;
 
   return (
-    <div className="cart-backdrop" onClick={closeDrawer}>
+    <div className="cart-backdrop">
       <div
         className="cart-drawer open"
         role="dialog"

--- a/src/styles/pages/CartDrawer.scss
+++ b/src/styles/pages/CartDrawer.scss
@@ -11,6 +11,7 @@
   transition: right 0.3s ease-in-out;
   display: flex;
   flex-direction: column;
+  pointer-events: auto;
 
   &.open {
     right: 0;
@@ -109,6 +110,7 @@
   z-index: 999;
   display: flex;
   justify-content: flex-end;
+  pointer-events: none;
 }
 
 .cart-item-content {


### PR DESCRIPTION
## Summary
- prevent overlay from intercepting events
- keep drawer interactive so page can still scroll when open

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880a419a2d083289edaca247439ed1d