### PR TITLE
Fix scroll restoration on browser back

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -25,24 +25,27 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
 
   useEffect(() => {
-    if (typeof window !== 'undefined' && 'scrollRestoration' in window.history) {
-      window.history.scrollRestoration = 'manual';
-    }
-  }, []);
+    let shouldScroll = true;
 
-  useEffect(() => {
+    router.beforePopState(() => {
+      shouldScroll = false;
+      return true;
+    });
+
     const handleRouteChange = () => {
-      if (typeof window !== 'undefined') {
+      if (shouldScroll && typeof window !== 'undefined') {
         window.scrollTo(0, 0);
       }
+      shouldScroll = true;
     };
 
     router.events.on('routeChangeComplete', handleRouteChange);
 
     return () => {
+      router.beforePopState(() => true);
       router.events.off('routeChangeComplete', handleRouteChange);
     };
-  }, [router.events]);
+  }, [router]);
 
   return (
     <AuthProvider>


### PR DESCRIPTION
## Summary
- respect browser scroll position when navigating back
- always scroll to top for normal navigations

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880ac6cfef8832881fd802fbca8329e