### PR TITLE
Fix scroll reset on hash navigation

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -32,9 +32,11 @@ export default function MyApp({ Component, pageProps }: AppProps) {
     };
 
     router.events.on('routeChangeComplete', handleRouteChange);
+    router.events.on('hashChangeComplete', handleRouteChange);
 
     return () => {
       router.events.off('routeChangeComplete', handleRouteChange);
+      router.events.off('hashChangeComplete', handleRouteChange);
     };
   }, [router]);
 


### PR DESCRIPTION
## Summary
- ensure clicking links with hash anchors resets scroll

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880c54d98f88328a27c26894766dac7