### PR TITLE
Fix approval gating for customer metafields

### DIFF
--- a/src/pages/api/shopify/get-customer.ts
+++ b/src/pages/api/shopify/get-customer.ts
@@ -101,14 +101,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
     }
 
+    const isApproved = (val?: string | null) => {
+      if (!val) return false;
+      return ['approved', 'true', '1', 'yes'].includes(val.trim().toLowerCase());
+    };
+
     return res.status(200).json({
-  success: true,
-  customer: {
-    ...customer,
-    note,
-    approved: customer.metafield?.value === 'Approved', // ✅ include approval flag
-  }
-});
+      success: true,
+      customer: {
+        ...customer,
+        note,
+        approved: isApproved(customer.metafield?.value),
+      },
+    });
 
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'An unknown error occurred';

--- a/src/pages/api/shopify/verify-customer.ts
+++ b/src/pages/api/shopify/verify-customer.ts
@@ -55,11 +55,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const customer = json.data.customer;
 
+    const isApproved = (val?: string | null) => {
+      if (!val) return false;
+      return ['approved', 'true', '1', 'yes'].includes(val.trim().toLowerCase());
+    };
+
     return res.status(200).json({
       success: true,
       customer: {
         ...customer,
-        approved: customer.metafield?.value === 'Approved',
+        approved: isApproved(customer.metafield?.value),
       },
     });
   } catch (error: unknown) {


### PR DESCRIPTION
## Summary
- accept multiple values for the `approved` customer metafield
- update `/api/shopify/get-customer` and `/api/shopify/verify-customer`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688226ecefb883289df9829bf4435eb2