### PR TITLE
Switch approval check to customer tags

### DIFF
--- a/src/pages/api/shopify/verify-customer.ts
+++ b/src/pages/api/shopify/verify-customer.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 const SHOPIFY_DOMAIN = process.env.SHOPIFY_STORE_DOMAIN!;
 const STOREFRONT_TOKEN = process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN!;
 const STOREFRONT_URL = `https://${SHOPIFY_DOMAIN}/api/2024-04/graphql.json`;
+const ADMIN_API_KEY = process.env.SHOPIFY_ADMIN_API_KEY!;
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -55,16 +56,33 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const customer = json.data.customer;
 
-    const isApproved = (val?: string | null) => {
-      if (!val) return false;
-      return ['approved', 'true', '1', 'yes'].includes(val.trim().toLowerCase());
-    };
+    let tags: string[] = [];
+    if (customer.email) {
+      const adminRes = await fetch(`https://${SHOPIFY_DOMAIN}/admin/api/2023-01/customers/search.json?query=email:${encodeURIComponent(customer.email)}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Shopify-Access-Token': ADMIN_API_KEY,
+        },
+      });
+      const adminJson = await adminRes.json();
+      if (adminJson.customers && adminJson.customers.length > 0) {
+        const adminCustomer = adminJson.customers[0];
+        if (adminCustomer.tags) {
+          tags = adminCustomer.tags.split(',').map((t: string) => t.trim()).filter(Boolean);
+        }
+      }
+    }
+
+    const isApproved = (t: string[]) =>
+      t.map((tag) => tag.toLowerCase()).includes('approved');
 
     return res.status(200).json({
       success: true,
       customer: {
         ...customer,
-        approved: isApproved(customer.metafield?.value),
+        tags,
+        approved: isApproved(tags),
       },
     });
   } catch (error: unknown) {


### PR DESCRIPTION
## Summary
- query customer tags via Shopify Admin API
- determine approval status from the `Approved` tag

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68822d6c536c8328b087069dab65dbb5