### PR TITLE
Add server-driven auth headers

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-'use client'
+import { headers } from 'next/headers';
 import '@/styles/globals.css';
 import '@/styles/pages/home.scss';
 import '@/styles/pages/footer.scss';
@@ -25,12 +25,17 @@ import { ToastProvider } from '@/context/ToastContext';
 import { ReactNode } from 'react';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const headerList = headers();
+  const authHeaders = {
+    'x-customer-authenticated': headerList.get('x-customer-authenticated') ?? undefined,
+    'x-customer-email': headerList.get('x-customer-email') ?? undefined,
+  };
   return (
     <html lang="en">
       <head />
       <body>
         <ToastProvider>
-          <AuthProvider>
+          <AuthProvider initialHeaders={authHeaders}>
             <FavouritesProvider>
               <CartProvider>
                 <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100dvh' }}>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -21,14 +21,19 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-export function AuthProvider({ children }: { children: ReactNode }) {
-  const initialHeaders =
-    typeof window !== 'undefined'
-      ? (window as any)?.__NEXT_DATA__?.props?.headers
-      : undefined;
+interface AuthProviderProps {
+  children: ReactNode;
+  initialHeaders?: Record<string, string | undefined>;
+}
 
-  const headerAuthenticated = initialHeaders?.['x-customer-authenticated'] === 'true';
-  const headerEmail = initialHeaders?.['x-customer-email'];
+export function AuthProvider({ children, initialHeaders }: AuthProviderProps) {
+  const headersData =
+    initialHeaders ??
+    (typeof window !== 'undefined'
+      ? (window as any)?.__NEXT_DATA__?.props?.headers
+      : undefined);
+  const headerAuthenticated = headersData?.['x-customer-authenticated'] === 'true';
+  const headerEmail = headersData?.['x-customer-email'];
 
   const [isAuthenticated, setIsAuthenticated] = useState(headerAuthenticated);
   const [user, setUser] = useState<ShopifyCustomer | null>(

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,5 @@
-import type { AppProps } from 'next/app';
+import type { AppProps, AppContext } from 'next/app';
+import App from 'next/app';
 import Head from 'next/head'; 
 import '@/styles/globals.css';
 import '@/styles/pages/home.scss';
@@ -24,12 +25,12 @@ import CartDrawer from '@/components/CartDrawer';
 import { FavouritesProvider } from '@/context/FavouritesContext';
 import { ToastProvider } from '@/context/ToastContext';
 
-export default function MyApp({ Component, pageProps }: AppProps) {
+export default function MyApp({ Component, pageProps }: AppProps<{ headers?: Record<string, string | undefined> }>) {
 
 
   return (
     <ToastProvider>
-      <AuthProvider>
+      <AuthProvider initialHeaders={pageProps.headers}>
         <FavouritesProvider>
           <CartProvider>
           <Head>
@@ -58,3 +59,15 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   </ToastProvider>
   );
 }
+
+MyApp.getInitialProps = async (appContext: AppContext) => {
+  const appProps = await App.getInitialProps(appContext);
+  const req = appContext.ctx.req;
+  const headers = req
+    ? {
+        'x-customer-authenticated': req.headers['x-customer-authenticated'] as string | undefined,
+        'x-customer-email': req.headers['x-customer-email'] as string | undefined,
+      }
+    : undefined;
+  return { ...appProps, pageProps: { ...appProps.pageProps, headers } };
+};


### PR DESCRIPTION
## Summary
- read auth headers in `app/layout.tsx`
- pass headers to `AuthProvider`
- support headers via `_app.tsx` for Pages Router
- update `AuthProvider` to accept initial headers

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688631b57a848328aaa0e3823a92c686