### PR TITLE
Add use client directives

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { useCart } from '@/context/CartContext';
 import Image from 'next/image';
 import { useEffect } from 'react';

--- a/src/components/FavouriteToggle.tsx
+++ b/src/components/FavouriteToggle.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { useFavourites } from '@/context/FavouritesContext';
 import { useEffect, useState } from 'react';
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { useState } from 'react';
 import Link from 'next/link';
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,4 @@
+'use client'
 import Link from 'next/link';
 import Image from 'next/image';
 import { useCart } from '@/context/CartContext';

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { useRouter } from 'next/router';
 

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { createContext, useContext, useState, ReactNode } from 'react';
 import { useFavourites } from '@/context/FavouritesContext';
 import { useToast } from '@/context/ToastContext';

--- a/src/context/FavouritesContext.tsx
+++ b/src/context/FavouritesContext.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 
 export interface FavouriteItem {

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { createContext, useContext, useState, ReactNode, useCallback } from 'react';
 
 interface ToastContextType {


### PR DESCRIPTION
## Summary
- designate cart drawer, footer, header, favourite toggle, and context files as client components with `'use client'`

## Testing
- `npm install` *(fails: network access blocked)*
- `npm run lint` *(fails: Next not found due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_6886374d9f108328b4bfad3c871f640f