### PR TITLE
Update AuthContext to use next/navigation router

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { useRouter } from 'next/router';
+import { useRouter } from 'next/navigation';
 
 interface ShopifyCustomer {
   id: string;


### PR DESCRIPTION
## Summary
- use `next/navigation`'s `useRouter` hook

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm ci` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6886397e6d2c8328b18c2b8719069b5c