### PR TITLE
Rename Page props interface

### DIFF
--- a/src/app/product/[handle]/page.tsx
+++ b/src/app/product/[handle]/page.tsx
@@ -3,11 +3,11 @@ import { notFound } from 'next/navigation';
 import { shopifyFetch } from '@/lib/shopify';
 import ProductClient, { Product } from '@/components/ProductClient';
 
-interface PageProps {
+interface ProductPageProps {
   params: { handle: string };
 }
 
-export default async function Page({ params }: PageProps) {
+export default async function Page({ params }: ProductPageProps) {
   const header = headers();
   const isAuthenticated = header.get('x-customer-authenticated') === 'true';
 


### PR DESCRIPTION
## Summary
- rename local `PageProps` interface to `ProductPageProps`
- update `Page` function signature to use new interface

## Testing
- `yarn lint` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68863d05b07c8328a9a6c1bc34470623