### PR TITLE
Fix product page typing for Next.js

### DIFF
--- a/src/app/product/[handle]/page.tsx
+++ b/src/app/product/[handle]/page.tsx
@@ -1,13 +1,12 @@
 import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
+import type { PageProps } from 'next';
 import { shopifyFetch } from '@/lib/shopify';
 import ProductClient, { Product } from '@/components/ProductClient';
 
-interface ProductPageProps {
-  params: { handle: string };
-}
-
-export default async function Page({ params }: ProductPageProps) {
+export default async function Page({
+  params,
+}: PageProps<{ handle: string }>) {
   const header = headers();
   const isAuthenticated = header.get('x-customer-authenticated') === 'true';
 


### PR DESCRIPTION
## Summary
- align `/product/[handle]` page with Next.js `PageProps` typing

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next/server' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68863ff5849c832890ebc493e1d2e446