### PR TITLE
Fix header retrieval

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,8 +24,8 @@ import { FavouritesProvider } from '@/context/FavouritesContext';
 import { ToastProvider } from '@/context/ToastContext';
 import { ReactNode } from 'react';
 
-export default function RootLayout({ children }: { children: ReactNode }) {
-  const headerList = headers();
+export default async function RootLayout({ children }: { children: ReactNode }) {
+  const headerList = await headers();
   const authHeaders = {
     'x-customer-authenticated': headerList.get('x-customer-authenticated') ?? undefined,
     'x-customer-email': headerList.get('x-customer-email') ?? undefined,

--- a/src/app/product/[handle]/page.tsx
+++ b/src/app/product/[handle]/page.tsx
@@ -7,7 +7,7 @@ import ProductClient, { Product } from '@/components/ProductClient';
 export default async function Page({
   params,
 }: PageProps<{ handle: string }>) {
-  const header = headers();
+  const header = await headers();
   const isAuthenticated = header.get('x-customer-authenticated') === 'true';
 
   const query = `


### PR DESCRIPTION
## Summary
- ensure RootLayout correctly awaits `headers()`
- await `headers()` in product page for correct header type

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886454e80b883288bd6ab074cc0eda9