### PR TITLE
Fix PageProps import

### DIFF
--- a/src/app/product/[handle]/page.tsx
+++ b/src/app/product/[handle]/page.tsx
@@ -1,6 +1,6 @@
 import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
-import type { PageProps } from 'next';
+import type PageProps from 'next';
 import { shopifyFetch } from '@/lib/shopify';
 import ProductClient, { Product } from '@/components/ProductClient';
 


### PR DESCRIPTION
## Summary
- replace named import for `PageProps` with default import

## Testing
- `yarn build` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6886471aa3408328ba9d46d297471867