### PR TITLE
Remove async/await from RootLayout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,8 +24,8 @@ import { FavouritesProvider } from '@/context/FavouritesContext';
 import { ToastProvider } from '@/context/ToastContext';
 import { ReactNode } from 'react';
 
-export default async function RootLayout({ children }: { children: ReactNode }) {
-  const headerList = await headers();
+export default function RootLayout({ children }: { children: ReactNode }) {
+  const headerList = headers();
   const authHeaders = {
     'x-customer-authenticated': headerList.get('x-customer-authenticated') ?? undefined,
     'x-customer-email': headerList.get('x-customer-email') ?? undefined,


### PR DESCRIPTION
## Summary
- remove `async`/`await` usage from `RootLayout`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: missing `ts-node`)*

------
https://chatgpt.com/codex/tasks/task_e_688648cbb618832880f5cff99508c6bc