### PR TITLE
Update sitemap import path

### DIFF
--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import fs from 'fs';
 import path from 'path';
 import { SitemapStream, streamToPromise } from 'sitemap';
-import { shopifyFetch } from '../src/lib/shopify.js';
+import { shopifyFetch } from '../src/lib/shopify.ts';
 
 
 console.log('SHOPIFY_STORE_DOMAIN:', process.env.SHOPIFY_STORE_DOMAIN);


### PR DESCRIPTION
## Summary
- fix TypeScript import path in sitemap generation script

## Testing
- `npm run sitemap` *(fails: ts-node not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68864a3ab41c8328850598eb7ac5d729