### PR TITLE
Add sitemap configuration

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,23 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: 'https://www.auricle.co.uk',
+  generateRobotsTxt: true,
+  trailingSlash: false,
+  robotsTxtOptions: {
+    policies: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: [
+          '/account',
+          '/register',
+          '/sign-in',
+          '/cart',
+          '/api/',
+          '/studio/',
+          '/admin/',
+        ],
+      },
+    ],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.5",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "next-sitemap": "^5.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `next-sitemap` as a dev dependency
- configure automatic sitemap generation via `next-sitemap.config.js`

## Testing
- `yarn add -D next-sitemap` *(fails: 403 response)*
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688650518d0c832892bef378a54ac345