### PR TITLE
Add automatic sitemap generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "next-sitemap",
+    "sitemap": "next-sitemap",
     "start": "next start",
     "lint": "next lint"
 


### PR DESCRIPTION
## Summary
- run `next-sitemap` automatically after builds via `postbuild`
- keep `sitemap` script for manual runs

## Testing
- `yarn lint` *(fails: RequestError 403)*
- `yarn install` *(fails: RequestError 403)*

------
https://chatgpt.com/codex/tasks/task_e_688652b66e8c83288b31e578dbe54e83