### PR TITLE
Update next-sitemap dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "eslint-config-next": "15.3.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
-    "next-sitemap": "^5.7.0"
+    "next-sitemap": "^5.8.1"
   }
 }


### PR DESCRIPTION
## Summary
- update next-sitemap to `^5.8.1`

## Testing
- `yarn install` *(fails: 403 Forbidden)*
- `yarn build` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68872df056808328a15e692bcc4cbb2c