### PR TITLE
Check customer cookie before verifying auth

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -35,6 +35,17 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
   useEffect(() => {
     if (initialUser) return; // skip re-check if we already have initialUser
 
+    const hasCustomerSession = document.cookie
+      .split(';')
+      .some((c) => c.trim().startsWith('customer_session='));
+
+    if (!hasCustomerSession) {
+      setUser(null);
+      setIsAuthenticated(false);
+      setLoading(false);
+      return;
+    }
+
     const checkAuth = async () => {
       try {
         const response = await fetch('/api/shopify/verify-customer', {


### PR DESCRIPTION
## Summary
- avoid network request to verify auth when no customer session cookie is present

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688783f35c788328a72820bf0182e0bd