### PR TITLE
Fix next-pwa fallback configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -29,15 +29,19 @@ const runtimeCaching = [
     urlPattern: /^\/(checkout|sign-in|register|reset-password|account|search)$/,
     handler: 'NetworkOnly',
   },
+  {
+    urlPattern: /^.*$/,
+    handler: 'NetworkOnly',
+    options: {
+      precacheFallback: { url: '/fallback.html' },
+    },
+  },
 ];
 
 const pwaConfig = withPWA({
   dest: 'public',
   disable: process.env.NODE_ENV === 'development',
   runtimeCaching,
-  fallbacks: {
-    document: '/fallback.html',
-  },
 });
 
 const nextConfig = {


### PR DESCRIPTION
## Summary
- remove deprecated `fallbacks.document`
- handle offline fallback in runtime caching via `precacheFallback`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68890b66a6408328be46bf1fd4f3f618