### PR TITLE
Fix next-pwa fallback configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,7 @@
 import withPWA from 'next-pwa';
 
+// PWA configuration with offline fallback support
+
 const runtimeCaching = [
   {
     urlPattern: /^\/_next\/static\/.*$/i,


### PR DESCRIPTION
## Summary
- document the offline fallback setup for `next-pwa`

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688911376fb8832895b7c7dd7a0f5c88