### PR TITLE
Enable offline PWA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/building-your-application/deploying) for more details.
 
+## Offline Support
+
+The application is configured as a Progressive Web App using `next-pwa`.
+When installed, the favourites page remains accessible even without a
+network connection because it loads data from `localStorage`.
+Account and checkout routes are excluded from the offline fallback and
+still require a connection.
+
 ## Documentation
 
 - [Product page rendering](docs/product-page.md)

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,25 @@
 import withPWA from 'next-pwa';
+import runtimeCaching from 'next-pwa/cache';
+
+const customCaching = [
+  ...runtimeCaching,
+  {
+    urlPattern: ({ url }) => url.pathname.startsWith('/favourites'),
+    handler: 'NetworkFirst',
+    options: { cacheName: 'favourites-pages' },
+  },
+];
 
 const pwaConfig = withPWA({
   dest: 'public',
   disable: process.env.NODE_ENV === 'development',
   register: true,
   skipWaiting: true,
+  runtimeCaching: customCaching,
+  fallbacks: {
+    document: '/fallback.html',
+  },
+  navigateFallbackDenylist: [/^\/account/, /^\/checkout/],
 });
 
 const nextConfig = {


### PR DESCRIPTION
## Summary
- enable offline behaviour using `next-pwa`
- cache `/favourites` for offline access
- document offline mode

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68891879b91c832887517728578ac825