### PR TITLE
Add middleware for dynamic routes

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+// Regex for public static files like .js, .css, images, etc.
+const PUBLIC_FILE = /\.(?:js|css|png|jpg|jpeg|gif|svg|webp|ico)$/i
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  // Skip Next.js internals and static assets
+  if (
+    pathname.startsWith('/_next') ||
+    pathname === '/favicon.ico' ||
+    pathname === '/sw.js' ||
+    PUBLIC_FILE.test(pathname)
+  ) {
+    return NextResponse.next()
+  }
+
+  // Place custom middleware logic for dynamic pages here
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: [
+    '/product/:path*',
+    '/account/:path*',
+    '/checkout/:path*',
+    '/collection/:path*',
+    '/piercing/:path*',
+    '/piercing-magazine/:path*',
+    '/favourites',
+    '/sign-in',
+    '/register',
+    '/reset-password',
+    '/search',
+  ],
+}


### PR DESCRIPTION
## Summary
- add a `middleware.ts` file that skips Next.js internals and static files
- restrict middleware to run only on dynamic user-facing paths like `/product` or `/account`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68891e53e1f88328a82053b1950536c2