### PR TITLE
Decouple search results from static props

### DIFF
--- a/src/pages/api/search-products.ts
+++ b/src/pages/api/search-products.ts
@@ -1,0 +1,60 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { shopifyFetch } from '@/lib/shopify';
+
+const SEARCH_QUERY = `
+  query searchProducts($query: String!, $first: Int!) {
+    products(first: $first, query: $query) {
+      edges {
+        node {
+          id
+          title
+          handle
+          images(first: 1) {
+            edges {
+              node { url }
+            }
+          }
+          variants(first: 1) {
+            edges {
+              node { sku }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+  if (!q) return res.status(200).json({ products: [] });
+
+  try {
+    const data = await shopifyFetch({
+      query: SEARCH_QUERY,
+      variables: { query: q, first: 20 },
+    });
+
+    const products = (data?.products?.edges || [])
+      .map((edge: any) => {
+        const variant = edge.node?.variants?.edges?.[0]?.node || {};
+        return {
+          id: edge.node?.id ?? '',
+          title: edge.node?.title ?? '',
+          handle: edge.node?.handle ?? '',
+          image: edge.node?.images?.edges?.[0]?.node?.url ?? null,
+          sku: (variant?.sku || '').trim(),
+        };
+      })
+      .filter((p: any) => p.id && p.title && p.handle);
+
+    return res.status(200).json({ products });
+  } catch (err) {
+    console.error('Search API error:', err);
+    return res.status(500).json({ message: 'Failed to fetch products' });
+  }
+}


### PR DESCRIPTION
## Summary
- fetch search results in the browser rather than bundling all products
- add `/api/search-products` to query Shopify

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889270834688328a6d7915b9db047cb