### PR TITLE
Fix cart drawer visibility and improve contrast

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -35,9 +35,9 @@ export default function CartDrawer() {
   }, [isDrawerOpen, closeDrawer]);
 
   return (
-    <div className="cart-backdrop">
+    <div className={`cart-backdrop${isDrawerOpen ? ' open' : ''}`}> 
       <div
-        className="cart-drawer open"
+        className={`cart-drawer${isDrawerOpen ? ' open' : ''}`}
         role="dialog"
         aria-modal="true"
         aria-labelledby="cart-drawer-title"
@@ -148,7 +148,7 @@ export default function CartDrawer() {
           <p
   style={{
     fontSize: '12px',
-    color: '#888',
+    color: '#595959',
     marginTop: '8px',
     marginBottom: '16px',
     textAlign: 'right',

--- a/src/styles/pages/CartDrawer.scss
+++ b/src/styles/pages/CartDrawer.scss
@@ -69,7 +69,7 @@
 }
 
 .empty-message {
-  color: #888;
+  color: #181818;
   font-size: 14px;
   text-align: center;
   margin-top: 40px;


### PR DESCRIPTION
## Summary
- ensure cart drawer only shows when opened
- improve accessibility contrast in cart drawer

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688930504ec883289874d15cee582270