### PR TITLE
Fix reset password POST data

### DIFF
--- a/src/pages/reset-password.tsx
+++ b/src/pages/reset-password.tsx
@@ -54,6 +54,7 @@ export default function ResetPassword() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          customerId: userId,
           resetToken,
           password: form.password,
         }),


### PR DESCRIPTION
## Summary
- fix POST body for reset password page so `customerId` is sent

## Testing
- `yarn lint` *(fails: package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6889354ab21c83289a1ca512641a5ea2