### PR TITLE
Add optional cookie domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/building-your-application/deploying) for more details.
 
+## Environment Variables
+
+- `AUTH_COOKIE_DOMAIN` (optional) - sets the `Domain` attribute on the `customer_session` cookie when defined.
+
 ## Documentation
 
 - [Product page rendering](docs/product-page.md)

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -3,13 +3,19 @@ export const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days in seconds
 
 export function setCustomerCookie(res: any, token: string) {
   const secure = process.env.NODE_ENV === 'production';
+  const domain = process.env.AUTH_COOKIE_DOMAIN;
   const expires = new Date(Date.now() + COOKIE_MAX_AGE * 1000);
-  const cookie = `${COOKIE_NAME}=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${COOKIE_MAX_AGE}; Expires=${expires.toUTCString()}${secure ? '; Secure' : ''}`;
+  let cookie = `${COOKIE_NAME}=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${COOKIE_MAX_AGE}; Expires=${expires.toUTCString()}`;
+  if (domain) cookie += `; Domain=${domain}`;
+  if (secure) cookie += '; Secure';
   res.setHeader('Set-Cookie', cookie);
 }
 
 export function clearCustomerCookie(res: any) {
   const secure = process.env.NODE_ENV === 'production';
-  const cookie = `${COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0${secure ? '; Secure' : ''}`;
+  const domain = process.env.AUTH_COOKIE_DOMAIN;
+  let cookie = `${COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`;
+  if (domain) cookie += `; Domain=${domain}`;
+  if (secure) cookie += '; Secure';
   res.setHeader('Set-Cookie', cookie);
 }


### PR DESCRIPTION
## Summary
- allow setting cookie `Domain` via env var
- document `AUTH_COOKIE_DOMAIN`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68893768125c8328a37438b5e49132a1