### PR TITLE
Fix cookie domain handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/b
 
 ## Environment Variables
 
-- `AUTH_COOKIE_DOMAIN` (optional) - sets the `Domain` attribute on the `customer_session` cookie when defined.
+- `AUTH_COOKIE_DOMAIN` (optional) - if set in production, this value becomes the `Domain` attribute on the `customer_session` cookie. Leave it unset during development so cookies work on `localhost`.
 
 ## Documentation
 

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -3,7 +3,9 @@ export const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days in seconds
 
 export function setCustomerCookie(res: any, token: string) {
   const secure = process.env.NODE_ENV === 'production';
-  const domain = process.env.AUTH_COOKIE_DOMAIN;
+  // Only apply the custom domain in production to avoid issues when running
+  // locally on a different host.
+  const domain = secure ? process.env.AUTH_COOKIE_DOMAIN : undefined;
   const expires = new Date(Date.now() + COOKIE_MAX_AGE * 1000);
   let cookie = `${COOKIE_NAME}=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${COOKIE_MAX_AGE}; Expires=${expires.toUTCString()}`;
   if (domain) cookie += `; Domain=${domain}`;
@@ -13,7 +15,7 @@ export function setCustomerCookie(res: any, token: string) {
 
 export function clearCustomerCookie(res: any) {
   const secure = process.env.NODE_ENV === 'production';
-  const domain = process.env.AUTH_COOKIE_DOMAIN;
+  const domain = secure ? process.env.AUTH_COOKIE_DOMAIN : undefined;
   let cookie = `${COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`;
   if (domain) cookie += `; Domain=${domain}`;
   if (secure) cookie += '; Secure';


### PR DESCRIPTION
## Summary
- ensure the custom cookie domain is only applied in production
- update README with usage note for `AUTH_COOKIE_DOMAIN`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688938960e2483288fc05ea9ac55fc57