### PR TITLE
Add canonical URLs to dynamic pages

### DIFF
--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -3,13 +3,15 @@ import Head from 'next/head';
 type SeoProps = {
   title: string;
   description?: string;
+  canonical?: string;
 };
 
-export default function Seo({ title, description }: SeoProps) {
+export default function Seo({ title, description, canonical }: SeoProps) {
   return (
     <Head>
       <title>{`${title} | AURICLE`}</title>
       {description && <meta name="description" content={description} />}
+      {canonical && <link rel="canonical" href={canonical} />}
     </Head>
   );
 }

--- a/src/pages/collection/[handle].tsx
+++ b/src/pages/collection/[handle].tsx
@@ -205,7 +205,11 @@ export default function CollectionPage({ products, title, seoTitle, seoDescripti
 
   return (
     <>
-      <Seo title={seoTitle || title} description={seoDescription || undefined} />
+      <Seo
+        title={seoTitle || title}
+        description={seoDescription || undefined}
+        canonical={`https://www.auricle.co.uk/collection/${handle}`}
+      />
 <script
   type="application/ld+json"
   dangerouslySetInnerHTML={{

--- a/src/pages/piercing-magazine/[slug].tsx
+++ b/src/pages/piercing-magazine/[slug].tsx
@@ -5,6 +5,7 @@ import { marked } from 'marked';
 import Image from 'next/image';
 import Link from 'next/link';
 import Head from 'next/head';
+import Seo from '@/components/Seo';
 import type { GetStaticProps, GetStaticPaths } from 'next';
 
 interface BlogPostProps {
@@ -21,9 +22,12 @@ interface BlogPostProps {
 export default function BlogPost({ title, description, content, image, slug, prev, next, datePublished }: BlogPostProps) {
   return (
     <>
+      <Seo
+        title={title}
+        description={description || `Read ${title} on the AURICLE piercing magazine.`}
+        canonical={`https://www.auricle.co.uk/piercing-magazine/${slug}`}
+      />
       <Head>
-        <title>{title} | AURICLE</title>
-        <meta name="description" content={description || `Read ${title} on the AURICLE piercing magazine.`} />
         <meta property="og:type" content="article" />
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description || ''} />

--- a/src/pages/product/[handle].tsx
+++ b/src/pages/product/[handle].tsx
@@ -204,9 +204,12 @@ const formattedPrice = rawPrice % 1 === 0 ? rawPrice.toFixed(0) : rawPrice.toFix
     
     <>
     <Seo
-    title={getFieldValue('title') || product.title}
-    description={getFieldValue('description') || `Buy ${product.title} in 14k gold or titanium.`}
-  />
+      title={getFieldValue('title') || product.title}
+      description={
+        getFieldValue('description') || `Buy ${product.title} in 14k gold or titanium.`
+      }
+      canonical={`https://www.auricle.co.uk/product/${product.handle}`}
+    />
 
 <script
   type="application/ld+json"


### PR DESCRIPTION
## Summary
- update `<Seo>` component with optional `canonical` prop
- provide canonical URLs for product, collection, and blog pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68893d21f4d08328825bce56c931c907