### PR TITLE
Remove duplicate theme color meta

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -51,7 +51,6 @@ export default function MyApp({ Component, pageProps }: MyAppProps) {
               <link rel="manifest" href="/site.webmanifest" />
               <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#181818" />
               <meta name="msapplication-TileColor" content="#ffffff" />
-              <meta name="theme-color" content="#ffffff" />
             </Head>
             <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100dvh' }}>
               <Header />


### PR DESCRIPTION
## Summary
- keep a single `<meta name="theme-color" />` in `_app.tsx`

## Testing
- `yarn lint` *(fails: package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68893e516b248328a528782c2ec1dde4