### PR TITLE
Fix missing alt text on collection page

### DIFF
--- a/src/pages/collection/[handle].tsx
+++ b/src/pages/collection/[handle].tsx
@@ -309,7 +309,7 @@ return (
   <div className="product-image-wrapper">
     <Image
       src={image?.url || '/placeholder.png'}
-      alt=""
+      alt={image?.altText || product.title}
       width={1200}
       height={1500}
       priority={index === 0}


### PR DESCRIPTION
## Summary
- set alt text for product images on collection pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68893f8c4cd48328a2fb1e9af5840eac