### PR TITLE
Add SEO metadata to auth pages

### DIFF
--- a/src/pages/account/reset/[id]/[token]/index.tsx
+++ b/src/pages/account/reset/[id]/[token]/index.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
+import Seo from "@/components/Seo";
 
 export default function ResetPassword() {
   const router = useRouter();
@@ -74,7 +75,12 @@ export default function ResetPassword() {
   };
 
   return (
-    <main className="reset-password-page">
+    <>
+      <Seo
+        title="Reset Password"
+        description="Choose a new password for your AURICLE account."
+      />
+      <main className="reset-password-page">
       <div className="reset-password-container">
       <div className="reset-password-info">
           <h1>Reset Password</h1>
@@ -98,5 +104,6 @@ export default function ResetPassword() {
       {status === "success" && <p>Password reset! Redirecting…</p>}
       </div>
     </main>
+    </>
   );
 }

--- a/src/pages/register.tsx
+++ b/src/pages/register.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
+import Seo from '@/components/Seo';
 
 export default function Register() {
   const [form, setForm] = useState({
@@ -39,7 +40,12 @@ export default function Register() {
   };
 
   return (
-    <main className="register-page">
+    <>
+      <Seo
+        title="Register"
+        description="Create a free B2B account to buy piercing jewellery from AURICLE."
+      />
+      <main className="register-page">
       <div className="register-container">
         <div className="register-info">
           <h1>REGISTER FREE</h1>
@@ -107,5 +113,6 @@ export default function Register() {
         </form>
       </div>
     </main>
+    </>
   );
 }

--- a/src/pages/sign-in.tsx
+++ b/src/pages/sign-in.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
+import Seo from '@/components/Seo';
 
 export default function SignIn() {
   const [form, setForm] = useState({ email: '', password: '' });
@@ -64,7 +65,12 @@ export default function SignIn() {
   };
 
   return (
-    <main className="sign-in-page">
+    <>
+      <Seo
+        title="Sign In"
+        description="Sign in to your AURICLE wholesale account."
+      />
+      <main className="sign-in-page">
       <div className="sign-in-container">
         <div className="sign-in-info">
           <h1>SIGN IN</h1>
@@ -176,5 +182,6 @@ export default function SignIn() {
         )}
       </div>
     </main>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- include `<Seo>` on sign-in, register and reset password pages
- give each page a concise title and description for search engines

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889405afcdc8328917c7b5c9fefdcf0