### PR TITLE
Include credentials for cookie auth

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -53,6 +53,7 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
       const res = await fetch('/api/shopify/verify-customer', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
       });
 
       if (res.ok) {
@@ -98,6 +99,7 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password }),
+        credentials: 'include',
       });
 
       const data = await response.json();
@@ -109,6 +111,7 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
         const userResponse = await fetch('/api/shopify/get-customer', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
         });
 
         if (userResponse.ok) {
@@ -131,7 +134,7 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
   };
 
   const signOut = async () => {
-    await fetch('/api/shopify/logout', { method: 'POST' });
+    await fetch('/api/shopify/logout', { method: 'POST', credentials: 'include' });
     setIsAuthenticated(false);
     setUser(null);
     router.push('/');
@@ -142,6 +145,7 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
       const res = await fetch('/api/shopify/get-customer', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
       });
 
       if (res.ok) {

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -16,7 +16,8 @@ export default function AccountPage() {
   const { isAuthenticated, user, loading } = useAuth();
   const router = useRouter();
 
-  const fetcher = (url: string) => fetch(url).then((res) => res.json());
+  const fetcher = (url: string) =>
+    fetch(url, { credentials: "include" }).then((res) => res.json());
 
   const {
     data: customerData,


### PR DESCRIPTION
## Summary
- include `credentials: 'include'` when hitting auth endpoints
- ensure account page SWR fetcher also sends credentials

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6889b314340c8328b8e1aa8f805076ae