### PR TITLE
Fix login session verification

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -39,16 +39,6 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
   const router = useRouter();
 
   const verifySession = async (): Promise<boolean> => {
-    const hasCustomerSession = document.cookie
-      .split(';')
-      .some((c) => c.trim().startsWith('customer_session='));
-
-    if (!hasCustomerSession) {
-      setIsAuthenticated(false);
-      setUser(null);
-      return false;
-    }
-
     try {
       const res = await fetch('/api/shopify/verify-customer', {
         method: 'POST',

--- a/src/pages/sign-in.tsx
+++ b/src/pages/sign-in.tsx
@@ -35,7 +35,7 @@ export default function SignIn() {
       }, 100);
     } else {
       setStatus('error');
-      setErrorMessage('Your credentials are incorrect. Please try again.');
+      setErrorMessage(result.error || 'Your credentials are incorrect. Please try again.');
     }
   };
 


### PR DESCRIPTION
## Summary
- ensure the auth session is verified server-side instead of relying on a cookie that is HTTP-only
- surface backend error message when sign-in fails

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6889b4dc5f488328ab3b15aa215c7f41