### PR TITLE
Fix auth flicker on static product page

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -6,6 +6,7 @@ import {
   ReactNode,
 } from 'react';
 import { useRouter } from 'next/router';
+import { COOKIE_NAME } from '@/lib/cookies';
 
 export interface ShopifyCustomer {
   id: string;
@@ -72,7 +73,14 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
 
     const handleVisibility = () => {
       if (document.visibilityState === 'visible') {
-        verifySession().finally(() => setLoading(false));
+        const hasCookie = document.cookie
+          .split(';')
+          .some((c) => c.trim().startsWith(`${COOKIE_NAME}=`));
+        if (hasCookie) {
+          verifySession().finally(() => setLoading(false));
+        } else {
+          setLoading(false);
+        }
       }
     };
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import type { AppProps, AppContext, AppInitialProps } from 'next/app';
+import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import '@/styles/globals.css';
 import '@/styles/pages/home.scss';
@@ -25,22 +25,10 @@ import dynamic from 'next/dynamic';
 const CartDrawer = dynamic(() => import('@/components/CartDrawer'), { ssr: false });
 import { FavouritesProvider } from '@/context/FavouritesContext';
 import { ToastProvider } from '@/context/ToastContext';
-import type { ShopifyCustomer } from '@/lib/verifyCustomerSession';
-import { COOKIE_NAME, setCustomerCookie } from '@/lib/cookies';
-import App from 'next/app';
-
-interface MyAppProps extends AppProps {
-  pageProps: {
-    customer?: ShopifyCustomer | null;
-    [key: string]: unknown;
-  };
-}
-
-
-export default function MyApp({ Component, pageProps }: MyAppProps) {
+export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ToastProvider>
-      <AuthProvider initialUser={pageProps.customer || null}>
+      <AuthProvider>
         <FavouritesProvider>
           <CartProvider>
             <Head>
@@ -70,29 +58,3 @@ export default function MyApp({ Component, pageProps }: MyAppProps) {
   );
 }
 
-MyApp.getInitialProps = async (
-  appCtx: AppContext
-): Promise<AppInitialProps & { pageProps: { customer?: ShopifyCustomer | null } }> => {
-  const appProps = await App.getInitialProps(appCtx);
-
-  const req = appCtx.ctx.req;
-  const res = appCtx.ctx.res;
-  let customer: ShopifyCustomer | null = null;
-
-  if (req && res) {
-    const token = req.cookies?.[COOKIE_NAME];
-    if (token) {
-      const { verifyCustomerSession } = await import('@/lib/verifyCustomerSession');
-      customer = await verifyCustomerSession(token);
-      if (customer) setCustomerCookie(res, token);
-    }
-  }
-
-  return {
-    ...appProps,
-    pageProps: {
-      ...appProps.pageProps,
-      customer,
-    },
-  };
-};

--- a/src/pages/product/[handle].tsx
+++ b/src/pages/product/[handle].tsx
@@ -99,7 +99,7 @@ useEffect(() => {
 }, [selectedVariantId, variantEdges]);
 
 
-const { user, refreshUser } = useAuth();
+const { user, refreshUser, loading } = useAuth();
 const hasRefreshed = useRef(false);
 
 useEffect(() => {
@@ -269,8 +269,8 @@ const formattedPrice = rawPrice % 1 === 0 ? rawPrice.toFixed(0) : rawPrice.toFix
 
           <div className="product-info">
             <h1 style={{ fontSize: '20px', fontWeight: 600, marginBottom: '4px' }}>{product.title}</h1>
-            {user?.approved ? (
-  <>
+            {!loading && (user?.approved ? (
+              <>
     {/* Price */}
     <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
       <p style={{ fontSize: '14px', fontWeight: 500 }}>
@@ -469,10 +469,10 @@ const formattedPrice = rawPrice % 1 === 0 ? rawPrice.toFixed(0) : rawPrice.toFix
       VAT & shipping calculated at checkout
     </p>
   </>
-) : (
-  <div
-  style={{
-    marginTop: '24px',
+            ) : (
+              <div
+                style={{
+                  marginTop: '24px',
     padding: '16px',
     background: '#f9f9f9',
     border: '1px solid #ddd',
@@ -480,10 +480,10 @@ const formattedPrice = rawPrice % 1 === 0 ? rawPrice.toFixed(0) : rawPrice.toFix
     fontSize: '14px',
   }}
 >
-  <p style={{ fontWeight: 600 }}>CATALOGUE VIEW</p><br />
-  <p>Sign in to your wholesale account to view pricing.</p></div>
-
-)}
+              <p style={{ fontWeight: 600 }}>CATALOGUE VIEW</p><br />
+              <p>Sign in to your wholesale account to view pricing.</p>
+            </div>
+            ) )}
 
 
 


### PR DESCRIPTION
## Summary
- remove server auth check from `_app`
- check for `customer_session` cookie in `AuthProvider`
- hide product pricing until auth is loaded

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889d221c8dc832889c639d66c72589f