### PR TITLE
Fix search page loading message

### DIFF
--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -15,12 +15,13 @@ export default function SearchPage() {
   const router = useRouter();
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<ProductLite[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   // Load initial query from URL
   useEffect(() => {
     const initial = typeof router.query.q === 'string' ? router.query.q : '';
     setQuery(initial);
+    if (initial) setLoading(true);
   }, [router.query.q]);
 
   // Fetch results when query changes
@@ -62,6 +63,7 @@ export default function SearchPage() {
   // Update URL when query changes
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
+    setLoading(true);
     setQuery(value);
 
     router.replace(


### PR DESCRIPTION
## Summary
- ensure loading message appears during initial search
- mark loading when query comes from router or input

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889e369fe188328bfd2e4bf72a46b30