### PR TITLE
Fix missing OpenAI API key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/b
 ## Environment Variables
 
 - `AUTH_COOKIE_DOMAIN` (optional) - if set in production, this value becomes the `Domain` attribute on the `customer_session` cookie. Leave it unset during development so cookies work on `localhost`.
+- `OPENAI_API_KEY` - required for the chat feature. Set this to your OpenAI API key.
 
 ## Building
 

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -1,10 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import OpenAI from 'openai';
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const apiKey = process.env.OPENAI_API_KEY;
+
+if (!apiKey) {
+  console.warn('OPENAI_API_KEY environment variable is not set.');
+}
+
+const openai = new OpenAI({ apiKey });
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end();
+
+  if (!apiKey) {
+    return res.status(500).json({ error: 'OpenAI API key not configured' });
+  }
 
   const { messages } = req.body;
 


### PR DESCRIPTION
## Summary
- warn if `OPENAI_API_KEY` is missing and return an error instead of silently failing
- document `OPENAI_API_KEY` in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a041e15748328a47eda7f47b36193