### PR TITLE
Validate OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/b
 
 - `AUTH_COOKIE_DOMAIN` (optional) - if set in production, this value becomes the `Domain` attribute on the `customer_session` cookie. Leave it unset during development so cookies work on `localhost`.
 - `OPENAI_API_KEY` - required for the chat feature. Set this to your OpenAI API key.
+- Make sure this variable is configured when running locally or deploying.
 
 ## Building
 

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -2,14 +2,24 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import OpenAI from 'openai';
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
-
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
+
+  if (!process.env.OPENAI_API_KEY) {
+    console.warn('Missing OPENAI_API_KEY environment variable');
+    return res
+      .status(500)
+      .json({ error: 'Server misconfiguration: OpenAI API key not set' });
+  }
+
+  const openai = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+  });
 
   try {
     const { messages } = req.body;


### PR DESCRIPTION
## Summary
- validate `OPENAI_API_KEY` inside the chat API route
- warn and fail if the key isn't configured
- remind developers in `README.md` to set `OPENAI_API_KEY`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a0d5f5f748328ab9754a532263b35