### PR TITLE
Add reply sound effect to chat drawer

### DIFF
--- a/src/components/ChatDrawer.tsx
+++ b/src/components/ChatDrawer.tsx
@@ -40,6 +40,10 @@ const [emailCaptured, setEmailCaptured] = useState(false);
   const emailSentRef = useRef(false);
   const replySound = useRef<HTMLAudioElement | null>(null);
 
+  useEffect(() => {
+    replySound.current = new Audio('/message.mp3');
+  }, []);
+
 const isLoggedIn = false; // Replace this later with real auth check
 
   useEffect(() => {
@@ -166,6 +170,7 @@ setTimeout(() => {
         aria-modal="true"
         aria-labelledby="chat-drawer-title"
       >
+        <audio ref={replySound} src="/message.mp3" preload="auto" style={{ display: 'none' }} />
         <div className="cart-drawer-inner">
   <div
     className="cart-header"


### PR DESCRIPTION
## Summary
- instantiate `message.mp3` audio for reply notifications
- render hidden audio element inside chat drawer for preloading

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint errors in unrelated files)*
- `npx eslint src/components/ChatDrawer.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6890d78206b48328b2927f137ebd364c