### PR TITLE
Reorder typing indicator in chat drawer

### DIFF
--- a/src/components/ChatDrawer.tsx
+++ b/src/components/ChatDrawer.tsx
@@ -214,6 +214,20 @@ setTimeout(() => {
 
               </div>
             ))}
+            {isTyping && (
+              <div
+                style={{
+                  background: '#ececec',
+                  padding: '8px 12px',
+                  borderRadius: '6px',
+                  marginBottom: '8px',
+                  fontSize: '14px',
+                  color: '#181818',
+                }}
+              >
+                <strong>AURICLE:</strong> Typing…
+              </div>
+            )}
             {!isLoggedIn && !emailCaptured && (
   <div
     style={{
@@ -265,21 +279,6 @@ setTimeout(() => {
     </form>
   </div>
 )}
-
-            {isTyping && (
-              <div
-                style={{
-                  background: '#ececec',
-                  padding: '8px 12px',
-                  borderRadius: '6px',
-                  marginBottom: '8px',
-                  fontSize: '14px',
-                  color: '#181818',
-                }}
-              >
-                <strong>AURICLE:</strong> Typing…
-              </div>
-            )}
             <div ref={messagesEndRef} />
           </div>
 


### PR DESCRIPTION
## Summary
- show chat typing indicator before prompting for email capture
- keep messagesEndRef at end of message list

## Testing
- `npm run lint` *(fails: Unexpected any in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_6890db6c32c0832899e1971e862bce9d