### PR TITLE
Attach customer token to Shopify cart

### DIFF
--- a/src/pages/api/create-checkout.ts
+++ b/src/pages/api/create-checkout.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { COOKIE_NAME } from '@/lib/cookies';
 
 const SHOPIFY_DOMAIN = process.env.SHOPIFY_STORE_DOMAIN;
 const SHOPIFY_TOKEN = process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN;
@@ -9,6 +10,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const { items } = req.body;
+  const token = req.cookies[COOKIE_NAME];
 
   const lines = items.map((item: { variantId: string; quantity: number }) => ({
     merchandiseId: item.variantId,
@@ -30,12 +32,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
   `;
 
-  const variables = {
+  const variables: {
+    lines: { merchandiseId: string; quantity: number }[];
+    buyerIdentity: { countryCode: string; customerAccessToken?: string };
+  } = {
     lines,
     buyerIdentity: {
-      countryCode: "GB" // ✅ You can change this to "US", "IE", etc.
+      countryCode: "GB", // ✅ You can change this to "US", "IE", etc.
     },
   };
+
+  if (token) {
+    variables.buyerIdentity.customerAccessToken = token;
+  }
 
   const response = await fetch(`https://${SHOPIFY_DOMAIN}/api/2024-04/graphql.json`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- pass customer cookie through checkout creation for Shopify buyer identity
- update existing carts to associate customer token when present

## Testing
- `npm run lint` *(fails: Unexpected any in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68988c3c818c83289b5d10e4e81860b5