### PR TITLE
Include access token in sign-in response and persist session

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -97,6 +97,8 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
       if (response.ok && data.success) {
         setIsAuthenticated(true);
 
+        document.cookie = `customer_session=${encodeURIComponent(data.accessToken)}; domain=.auricle.co.uk; path=/; Secure; SameSite=None`;
+
         // Fetch user data
         const userResponse = await fetch('/api/shopify/get-customer', {
           method: 'POST',

--- a/src/pages/api/shopify/sign-in-customer.ts
+++ b/src/pages/api/shopify/sign-in-customer.ts
@@ -50,7 +50,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const json = await response.json();
 
-    
+
 
     if (json.errors || json.data.customerAccessTokenCreate.customerUserErrors.length > 0) {
       const message =
@@ -60,7 +60,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const { accessToken } = json.data.customerAccessTokenCreate.customerAccessToken;
     setCustomerCookie(res, accessToken);
-    return res.status(200).json({ success: true });
+    return res.status(200).json({ success: true, accessToken });
   } catch (error: unknown) {
     const message =
       error instanceof Error ? error.message : 'An unknown error occurred';


### PR DESCRIPTION
## Summary
- include access token in sign-in API response
- persist customer session in browser cookie after sign-in

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint errors in unrelated files)*
- `npx eslint src/pages/api/shopify/sign-in-customer.ts src/context/AuthContext.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6898a26363488328a2c1cbf45fa4ab73