### PR TITLE
Use env-based auth cookie domain

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -6,6 +6,7 @@ import {
   ReactNode,
 } from 'react';
 import { useRouter } from 'next/router';
+import { COOKIE_NAME, COOKIE_MAX_AGE } from '@/lib/cookies';
 
 export interface ShopifyCustomer {
   id: string;
@@ -97,7 +98,11 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
       if (response.ok && data.success) {
         setIsAuthenticated(true);
 
-        document.cookie = `customer_session=${encodeURIComponent(data.accessToken)}; domain=.auricle.co.uk; path=/; Secure; SameSite=None`;
+        const domain =
+          process.env.NEXT_PUBLIC_AUTH_COOKIE_DOMAIN || window.location.hostname;
+        document.cookie = `${COOKIE_NAME}=${encodeURIComponent(
+          data.accessToken,
+        )}; Domain=${domain}; Path=/; Secure; SameSite=None; Max-Age=${COOKIE_MAX_AGE}`;
 
         // Fetch user data
         const userResponse = await fetch('/api/shopify/get-customer', {


### PR DESCRIPTION
## Summary
- read auth cookie domain from `NEXT_PUBLIC_AUTH_COOKIE_DOMAIN` with fallback to current host
- set client session cookie with secure attributes and max age

## Testing
- `npm run lint` *(fails: Unexpected any, ...)*
- `curl -i -X POST http://localhost:3000/api/shopify/sign-in-customer` *(connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6898a6998a2c8328a2a4a32edf820b8c