### PR TITLE
Forward customer token in checkout creation and include cookies in requests

### DIFF
--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -102,6 +102,7 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ items: parsedItems }),
+              credentials: 'include',
             })
               .then((res) => res.json())
               .then((data) => {
@@ -150,6 +151,7 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ items }),
+          credentials: 'include',
         });
         const data = await res.json();
         setCheckoutUrl(data.checkoutUrl);

--- a/src/pages/api/create-checkout.ts
+++ b/src/pages/api/create-checkout.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { COOKIE_NAME } from '@/lib/cookies';
 
 const SHOPIFY_DOMAIN = process.env.SHOPIFY_STORE_DOMAIN;
 const SHOPIFY_TOKEN = process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN;
@@ -30,10 +31,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
   `;
 
-  const variables = {
+  const customerAccessToken = req.cookies?.[COOKIE_NAME];
+
+  const variables: {
+    lines: { merchandiseId: string; quantity: number }[];
+    buyerIdentity: {
+      countryCode: string;
+      customerAccessToken?: string;
+    };
+  } = {
     lines,
     buyerIdentity: {
-      countryCode: "GB" // ✅ You can change this to "US", "IE", etc.
+      countryCode: "GB", // ✅ You can change this to "US", "IE", etc.
+      ...(customerAccessToken ? { customerAccessToken } : {}),
     },
   };
 


### PR DESCRIPTION
## Summary
- Include customer session token when creating Shopify carts
- Ensure client checkout creation requests send cookies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any / unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6898aca066088328bf2fa5d2f4dec72f