### PR TITLE
Link carts to customer sessions via buyer identity update

### DIFF
--- a/src/pages/api/shopify/sign-in-customer.ts
+++ b/src/pages/api/shopify/sign-in-customer.ts
@@ -10,7 +10,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ success: false, error: 'Method not allowed' });
   }
 
-  const { email, password } = req.body;
+  const { email, password, checkoutId } = req.body;
 
   if (!email || !password) {
     return res.status(400).json({ success: false, error: 'Email and password are required' });
@@ -60,6 +60,31 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const { accessToken } = json.data.customerAccessTokenCreate.customerAccessToken;
     setCustomerCookie(res, accessToken);
+
+    if (checkoutId) {
+      const IDENTITY_MUTATION = `mutation cartBuyerIdentityUpdate($cartId: ID!, $buyerIdentity: CartBuyerIdentityInput!) { cartBuyerIdentityUpdate(cartId: $cartId, buyerIdentity: $buyerIdentity) { cart { id } userErrors { field message } } }`;
+      const variables = {
+        cartId: checkoutId,
+        buyerIdentity: {
+          countryCode: 'GB',
+          customerAccessToken: accessToken,
+        },
+      };
+      const bindRes = await fetch(STOREFRONT_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Shopify-Storefront-Access-Token': STOREFRONT_TOKEN,
+        },
+        body: JSON.stringify({ query: IDENTITY_MUTATION, variables }),
+      });
+      const bindJson = await bindRes.json();
+      const userErrors = bindJson.data?.cartBuyerIdentityUpdate?.userErrors;
+      if (userErrors?.length) {
+        console.error('Shopify cartBuyerIdentityUpdate user errors:', userErrors);
+      }
+    }
+
     return res.status(200).json({ success: true, accessToken });
   } catch (error: unknown) {
     const message =


### PR DESCRIPTION
## Summary
- bind cart updates to a logged-in customer by reading customer session token and running `cartBuyerIdentityUpdate`
- update customer sign-in API to optionally associate an existing cart with the authenticated user

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any and other lint errors)


------
https://chatgpt.com/codex/tasks/task_e_6898aea6bf6c83288b8a2ec5d4ddfd8c