### PR TITLE
Ensure checkout fetch requests include credentials

### DIFF
--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -93,6 +93,7 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id: storedId }),
+        credentials: 'include',
       })
         .then((res) => res.json())
         .then((data) => {
@@ -161,6 +162,7 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ checkoutId, items }),
+          credentials: 'include',
         });
         const data = await res.json();
         if (data.completed) {


### PR DESCRIPTION
## Summary
- Include `credentials: 'include'` on `get-checkout` requests to send session cookies
- Ensure checkout updates also send cookies by adding `credentials: 'include'`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898aea896f88328be020f59bf9a4092