### PR TITLE
Clear auth cookie on sign out

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -132,6 +132,11 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
 
   const signOut = async () => {
     await fetch('/api/shopify/logout', { method: 'POST', credentials: 'include' });
+
+    const domain =
+      process.env.NEXT_PUBLIC_AUTH_COOKIE_DOMAIN || window.location.hostname;
+    document.cookie = `${COOKIE_NAME}=; Domain=${domain}; Path=/; Secure; SameSite=None; Max-Age=0`;
+
     setIsAuthenticated(false);
     setUser(null);
     router.push('/');

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -1,15 +1,17 @@
 export const COOKIE_NAME = 'customer_session';
 export const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days in seconds
+const COOKIE_DOMAIN =
+  process.env.NEXT_PUBLIC_AUTH_COOKIE_DOMAIN || '.auricle.co.uk';
 
 export function setCustomerCookie(res: any, token: string) {
-  const domain = process.env.AUTH_COOKIE_DOMAIN || '.auricle.co.uk';
   const expires = new Date(Date.now() + COOKIE_MAX_AGE * 1000);
-  const cookie = `${COOKIE_NAME}=${encodeURIComponent(token)}; Path=/; SameSite=None; Max-Age=${COOKIE_MAX_AGE}; Expires=${expires.toUTCString()}; Domain=${domain}; Secure`;
+  const cookie = `${COOKIE_NAME}=${encodeURIComponent(
+    token,
+  )}; Path=/; SameSite=None; Max-Age=${COOKIE_MAX_AGE}; Expires=${expires.toUTCString()}; Domain=${COOKIE_DOMAIN}; Secure`;
   res.setHeader('Set-Cookie', cookie);
 }
 
 export function clearCustomerCookie(res: any) {
-  const domain = process.env.AUTH_COOKIE_DOMAIN || '.auricle.co.uk';
-  const cookie = `${COOKIE_NAME}=; Path=/; SameSite=None; Max-Age=0; Domain=${domain}; Secure`;
+  const cookie = `${COOKIE_NAME}=; Path=/; SameSite=None; Max-Age=0; Domain=${COOKIE_DOMAIN}; Secure`;
   res.setHeader('Set-Cookie', cookie);
 }


### PR DESCRIPTION
## Summary
- delete customer_session cookie on sign out using same domain as sign in
- standardize cookie domain logic with `NEXT_PUBLIC_AUTH_COOKIE_DOMAIN`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(errors: Unexpected any, unused vars, no-img-element, etc.)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_6898b87740788328a45dff9cc3782a3d