### PR TITLE
Ensure cart sync completes before checkout

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -15,6 +15,7 @@ export default function CartDrawer() {
     isDrawerOpen,
     closeDrawer,
     updateQuantity,
+    flushSync,
   } = useCart();
 
   const { addFavourite } = useFavourites();
@@ -121,9 +122,9 @@ export default function CartDrawer() {
           <a
   className={`checkout-button ${checkoutUrl ? '' : 'disabled'}`}
   href={checkoutUrl || '#'}
-  onClick={(e) => {
+  onClick={async (e) => {
+    e.preventDefault();
     if (!checkoutUrl) {
-      e.preventDefault();
       return;
     }
 
@@ -139,6 +140,8 @@ export default function CartDrawer() {
         });
       }
     });
+    await flushSync();
+    window.location.href = checkoutUrl;
   }}
 >
   CHECKOUT


### PR DESCRIPTION
## Summary
- add `flushSync` method to cart context to wait for pending Shopify checkout sync
- await `flushSync` in cart drawer before navigating to checkout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx next lint --file src/context/CartContext.tsx --file src/components/CartDrawer.tsx`
- `npm run build` *(fails: fetch failed, getaddrinfo ENOTFOUND undefined)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6898b8354fcc83289d3d9446c0e9237f