### PR TITLE
Return checkout URL from flushSync

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -1,6 +1,6 @@
 import { useCart } from '@/context/CartContext';
 import Image from 'next/image';
-import { useEffect, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import { useFavourites } from '@/context/FavouritesContext';
 
 const formatPrice = (price: string | undefined) => {
@@ -20,10 +20,7 @@ export default function CartDrawer() {
 
   const { addFavourite } = useFavourites();
 
-  const checkoutUrlRef = useRef<string | null>(checkoutUrl);
-  useEffect(() => {
-    checkoutUrlRef.current = checkoutUrl;
-  }, [checkoutUrl]);
+  const [isCheckingOut, setIsCheckingOut] = useState(false);
 
 
   useEffect(() => {
@@ -125,31 +122,35 @@ export default function CartDrawer() {
           )}
 
           <a
-  className={`checkout-button ${checkoutUrl ? '' : 'disabled'}`}
-  href={checkoutUrl || '#'}
-  onClick={async (e) => {
-    e.preventDefault();
-    await flushSync();
-    const url = checkoutUrlRef.current;
-    if (!url) return;
+            className={`checkout-button ${
+              checkoutUrl && !isCheckingOut ? '' : 'disabled'
+            }`}
+            href={checkoutUrl || '#'}
+            onClick={async (e) => {
+              e.preventDefault();
+              if (isCheckingOut) return;
+              setIsCheckingOut(true);
+              const url = await flushSync();
+              setIsCheckingOut(false);
+              if (!url) return;
 
-    cartItems.forEach((item) => {
-      if (item.handle) {
-        addFavourite({
-          handle: item.handle,
-          title: item.title || '',
-          image: item.image,
-          price: item.price,
-          metafields: item.metafields,
-          orderAgain: true, // ✅ This sets the flag
-        });
-      }
-    });
-    window.location.href = url;
-  }}
->
-  CHECKOUT
-</a>
+              cartItems.forEach((item) => {
+                if (item.handle) {
+                  addFavourite({
+                    handle: item.handle,
+                    title: item.title || '',
+                    image: item.image,
+                    price: item.price,
+                    metafields: item.metafields,
+                    orderAgain: true, // ✅ This sets the flag
+                  });
+                }
+              });
+              window.location.href = url;
+            }}
+          >
+            {isCheckingOut ? 'LOADING…' : 'CHECKOUT'}
+          </a>
 
 
           <p

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -33,7 +33,7 @@ interface CartContextType {
   isDrawerOpen: boolean;
   openDrawer: () => void;
   closeDrawer: () => void;
-  flushSync: () => Promise<void>;
+  flushSync: () => Promise<string | null>;
 }
 
 const CartContext = createContext<CartContextType | undefined>(undefined);
@@ -46,6 +46,7 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
   const [checkoutId, setCheckoutId] = useState<string | null>(null);
   const [checkoutUrl, setCheckoutUrl] = useState<string | null>(null);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const checkoutUrlRef = useRef<string | null>(checkoutUrl);
 
   const syncTimeout = useRef<NodeJS.Timeout | null>(null);
   const pendingSync = useRef<Promise<void> | null>(null);
@@ -57,6 +58,10 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
 
   const openDrawer = () => setIsDrawerOpen(true);
   const closeDrawer = () => setIsDrawerOpen(false);
+
+  useEffect(() => {
+    checkoutUrlRef.current = checkoutUrl;
+  }, [checkoutUrl]);
 
   const scheduleSync = (items: CartItem[]) => {
     if (syncTimeout.current) {
@@ -78,7 +83,7 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
     }, 300);
   };
 
-  const flushSync = async () => {
+  const flushSync = async (): Promise<string | null> => {
     if (syncTimeout.current) {
       clearTimeout(syncTimeout.current);
       syncTimeout.current = null;
@@ -93,6 +98,7 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
     if (pendingSync.current) {
       await pendingSync.current;
     }
+    return checkoutUrlRef.current;
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure `flushSync` returns the latest checkout URL from the cart context
- await this value in the cart drawer and disable the checkout button while syncing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6898e1038fb483289d2fb987677c91d7