### PR TITLE
Preserve variant metadata in cart

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -8,6 +8,17 @@ const formatPrice = (price: string | undefined) => {
   return num % 1 === 0 ? num.toFixed(0) : num.toFixed(2);
 };
 
+const displayTitle = (title?: string, variantTitle?: string) => {
+  const t = (s?: string) => (s || '').trim();
+  const isDefault = (s?: string) => /^default\s*title$/i.test(s || '');
+  const base = t(title);
+  const variant = t(variantTitle);
+  if (!variant || isDefault(variant) || variant.toLowerCase() === base.toLowerCase()) {
+    return base || 'Untitled Product';
+  }
+  return `${base} | ${variant}`;
+};
+
 export default function CartDrawer() {
   const {
     cartItems,
@@ -62,7 +73,7 @@ export default function CartDrawer() {
                     {item.image && (
                       <Image
                         src={item.image}
-                        alt={item.title || ''}
+                        alt={displayTitle(item.title, item.variantTitle)}
                         width={600}
                         height={750}
                         style={{
@@ -76,7 +87,7 @@ export default function CartDrawer() {
 
                     <div className="cart-image-overlay">
                       <div className="overlay-title">
-                        {item.title || 'Untitled Product'}
+                        {displayTitle(item.title, item.variantTitle)}
                       </div>
                       <div className="overlay-controls">
                         <div className="quantity-controls">

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -13,6 +13,8 @@ export interface CartItem {
   variantId: string;
   quantity: number;
   title?: string;
+  variantTitle?: string;
+  selectedOptions?: { name: string; value: string }[];
   price?: string;
   image?: string;
   handle?: string;
@@ -170,6 +172,8 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
                 quantity: edge.node.quantity,
                 // Preserve existing metadata from localStorage
                 title: existingItem?.title,
+                variantTitle: existingItem?.variantTitle,
+                selectedOptions: existingItem?.selectedOptions,
                 price: existingItem?.price,
                 image: existingItem?.image,
                 handle: existingItem?.handle,
@@ -274,6 +278,8 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
                 quantity: edge.node.quantity,
                 // Preserve existing metadata
                 title: existingItem?.title,
+                variantTitle: existingItem?.variantTitle,
+                selectedOptions: existingItem?.selectedOptions,
                 price: existingItem?.price,
                 image: existingItem?.image,
                 handle: existingItem?.handle,


### PR DESCRIPTION
## Summary
- keep product and variant titles separate for cart items
- remember variant options and metadata when syncing checkout
- hide "Default Title" in cart drawer

## Testing
- `npm run lint -- --fix` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'debug', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a0308b7eb08328bd077fc6587b4a61