### PR TITLE
Add social metafield support for account settings

### DIFF
--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -196,7 +196,8 @@ function AccountSettingsForm({ customer, refreshCustomer }: { customer: any; ref
   const [phone, setPhone] = useState(customer?.phone || "");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [website, setWebsite] = useState(customer?.note || ""); // Now from note field
+  const [website, setWebsite] = useState(customer?.website || "");
+  const [social, setSocial] = useState(customer?.social || "");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -207,7 +208,8 @@ function AccountSettingsForm({ customer, refreshCustomer }: { customer: any; ref
     setFirstName(newCustomer?.firstName || "");
     setLastName(newCustomer?.lastName || "");
     setPhone(newCustomer?.phone || "");
-    setWebsite(newCustomer?.note || "");
+    setWebsite(newCustomer?.website || "");
+    setSocial(newCustomer?.social || "");
     // Don't update password fields
   };
 
@@ -233,7 +235,7 @@ const fetchLatestCustomer = async () => {
     }
     setLoading(true);
       try {
-        const payload: any = { firstName, lastName, phone, note: website };
+        const payload: any = { firstName, lastName, phone, website, social };
         if (password) payload.password = password;
         const res = await fetch("/api/shopify/update-customer", {
           method: "POST",
@@ -318,13 +320,23 @@ const fetchLatestCustomer = async () => {
         />
       </label>
       <label>
-        Website / Social Media
+        Website
         <input
           type="url"
           name="website"
-          placeholder="https://your-site.com or @yourhandle"
+          placeholder="https://your-site.com"
           value={website}
           onChange={e => setWebsite(e.target.value)}
+        />
+      </label>
+      <label>
+        Social
+        <input
+          type="text"
+          name="social"
+          placeholder="@yourhandle"
+          value={social}
+          onChange={e => setSocial(e.target.value)}
         />
       </label>
       {error && <div style={{ color: 'red', marginBottom: 10 }}>{error}</div>}

--- a/src/pages/api/shopify/get-customer.ts
+++ b/src/pages/api/shopify/get-customer.ts
@@ -29,8 +29,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         createdAt
         updatedAt
         metafield(namespace: "custom", key: "approved") {
-      value
-    }
+          value
+        }
+        website: metafield(namespace: "custom", key: "website") {
+          value
+        }
+        social: metafield(namespace: "custom", key: "social") {
+          value
+        }
         defaultAddress {
           id
           firstName
@@ -118,6 +124,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         note,
         tags,
         approved: isApproved(tags),
+        website: customer.website?.value || '',
+        social: customer.social?.value || '',
       },
     });
 


### PR DESCRIPTION
## Summary
- fetch and expose `custom.website` and `custom.social` customer metafields
- allow users to edit website and social handles in account settings
- upsert Shopify customer metafields for website and social on save

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3105a11988328b9aa941b845a2a28