### PR TITLE
Fix Shopify customer website metafield update

### DIFF
--- a/src/pages/api/shopify/update-customer.ts
+++ b/src/pages/api/shopify/update-customer.ts
@@ -137,21 +137,22 @@ const variables: {
 
           const upsertMetafield = async (key: string, value: string) => {
             const existingRes = await fetch(
-              `https://${SHOPIFY_DOMAIN}/admin/api/2023-01/customers/${customerId}/metafields.json?namespace=custom&key=${key}`,
+              `https://${SHOPIFY_DOMAIN}/admin/api/2023-01/customers/${customerId}/metafields.json?namespace=custom`,
               { method: 'GET', headers: adminHeaders }
             );
             const existingJson = await existingRes.json();
-            const metafield = existingJson.metafields?.[0];
+            const metafield = existingJson.metafields?.find((m: any) => m.key === key);
             if (metafield) {
               await fetch(
                 `https://${SHOPIFY_DOMAIN}/admin/api/2023-01/metafields/${metafield.id}.json`,
                 {
                   method: 'PUT',
                   headers: adminHeaders,
-                  body: JSON.stringify({ metafield: { id: metafield.id, value, type: 'single_line_text_field' } }),
+                  body: JSON.stringify({ metafield: { id: metafield.id, value, type: metafield.type } }),
                 }
               );
             } else {
+              const type = key === 'website' ? 'url' : 'single_line_text_field';
               await fetch(
                 `https://${SHOPIFY_DOMAIN}/admin/api/2023-01/customers/${customerId}/metafields.json`,
                 {
@@ -161,7 +162,7 @@ const variables: {
                     metafield: {
                       namespace: 'custom',
                       key,
-                      type: 'single_line_text_field',
+                      type,
                       value,
                     },
                   }),


### PR DESCRIPTION
## Summary
- ensure update-customer API targets the correct Shopify metafield key
- handle Shopify metafield type for website as URL instead of text

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a3133ba6cc8328b58478f6a87a3f90