### PR TITLE
Add Shopify page queries and information route

### DIFF
--- a/src/lib/shopify-queries.ts
+++ b/src/lib/shopify-queries.ts
@@ -25,3 +25,28 @@ export const GET_ALL_PRODUCTS = `
     }
   }
 `;
+
+export const GET_ALL_PAGES = `
+  {
+    pages(first: 250) {
+      edges {
+        node {
+          handle
+        }
+      }
+    }
+  }
+`;
+
+export const GET_PAGE_BY_HANDLE = `
+  query getPageByHandle($handle: String!) {
+    pageByHandle(handle: $handle) {
+      title
+      bodyHtml
+      seo {
+        title
+        description
+      }
+    }
+  }
+`;

--- a/src/pages/information/[handle].tsx
+++ b/src/pages/information/[handle].tsx
@@ -1,0 +1,83 @@
+import type {
+  GetStaticPaths,
+  GetStaticProps,
+  GetStaticPropsContext,
+} from 'next';
+import { shopifyFetch } from '@/lib/shopify';
+import {
+  GET_ALL_PAGES,
+  GET_PAGE_BY_HANDLE,
+} from '@/lib/shopify-queries';
+import Seo from '@/components/Seo';
+
+interface PageSeo {
+  title?: string | null;
+  description?: string | null;
+}
+
+interface PageData {
+  title: string;
+  bodyHtml: string;
+  seo?: PageSeo;
+}
+
+interface PageProps {
+  page: PageData;
+}
+
+export default function InformationPage({ page }: PageProps) {
+  return (
+    <>
+      <Seo
+        title={page.seo?.title || page.title}
+        description={page.seo?.description || undefined}
+      />
+      <main style={{ padding: '16px' }}>
+        <h1 style={{ marginBottom: '16px' }}>{page.title}</h1>
+        <div dangerouslySetInnerHTML={{ __html: page.bodyHtml }} />
+      </main>
+    </>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const data = await shopifyFetch({ query: GET_ALL_PAGES });
+
+  const paths = data.pages.edges.map(
+    (edge: { node: { handle: string } }) => ({
+      params: { handle: edge.node.handle },
+    })
+  );
+
+  return {
+    paths,
+    fallback: 'blocking',
+  };
+};
+
+export const getStaticProps: GetStaticProps<PageProps> = async (
+  context: GetStaticPropsContext
+) => {
+  const handle = context.params?.handle;
+
+  if (typeof handle !== 'string') {
+    return { notFound: true };
+  }
+
+  const data = await shopifyFetch({
+    query: GET_PAGE_BY_HANDLE,
+    variables: { handle },
+  });
+
+  if (!data.pageByHandle) {
+    return { notFound: true };
+  }
+
+  return {
+    props: {
+      page: data.pageByHandle,
+    },
+    revalidate: 60,
+  };
+};
+


### PR DESCRIPTION
## Summary
- add Shopify queries for page handles and page details
- implement `/information/[handle]` route to statically render pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b05d76b664832898b16fd41b0922a2