### PR TITLE
Use HTML parser with sanitization for information pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "resend": "^4.7.0",
     "sass": "^1.89.2",
     "sitemap": "^8.0.0",
-    "swr": "^2.3.4"
+    "swr": "^2.3.4",
+    "dompurify": "^3.0.6",
+    "html-react-parser": "^4.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/pages/information/[handle].tsx
+++ b/src/pages/information/[handle].tsx
@@ -3,6 +3,9 @@ import type {
   GetStaticProps,
   GetStaticPropsContext,
 } from 'next';
+import { useMemo } from 'react';
+import parse from 'html-react-parser';
+import DOMPurify from 'dompurify';
 import { shopifyFetch } from '@/lib/shopify';
 import {
   GET_ALL_PAGES,
@@ -26,6 +29,14 @@ interface PageProps {
 }
 
 export default function InformationPage({ page }: PageProps) {
+  const content = useMemo(() => {
+    const sanitized =
+      typeof window !== 'undefined'
+        ? DOMPurify.sanitize(page.bodyHtml)
+        : page.bodyHtml;
+    return parse(sanitized);
+  }, [page.bodyHtml]);
+
   return (
     <>
       <Seo
@@ -34,7 +45,7 @@ export default function InformationPage({ page }: PageProps) {
       />
       <main style={{ padding: '16px' }}>
         <h1 style={{ marginBottom: '16px' }}>{page.title}</h1>
-        <div dangerouslySetInnerHTML={{ __html: page.bodyHtml }} />
+        <div>{content}</div>
       </main>
     </>
   );


### PR DESCRIPTION
## Summary
- sanitize and parse Shopify page HTML before rendering
- add DOMPurify and html-react-parser dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dompurify)*
- `npm run lint` *(fails: React Hooks called conditionally and other lint errors)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b05e59b4188328a2116f986eb21426