### PR TITLE
Include Shopify pages in sitemap generation

### DIFF
--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -8,7 +8,7 @@ import { shopifyFetch } from '../src/lib/shopify.js';
 
 const DOMAIN = process.env.SITE_DOMAIN || 'http://localhost:3000';
 
-async function fetchShopifyHandles(type: 'products' | 'collections') {
+async function fetchShopifyHandles(type: 'products' | 'collections' | 'pages') {
   const query = `
     {
       ${type}(first: 250) {
@@ -75,6 +75,16 @@ async function generateSitemap() {
       url: `/collection/${handle}`,
       changefreq: 'weekly',
       priority: 0.8,
+    });
+  });
+
+  // Shopify information pages
+  const pageHandles = await fetchShopifyHandles('pages');
+  pageHandles.forEach((handle: string) => {
+    smStream.write({
+      url: `/information/${handle}`,
+      changefreq: 'monthly',
+      priority: 0.7,
     });
   });
 

--- a/src/pages/sitemap.tsx
+++ b/src/pages/sitemap.tsx
@@ -63,6 +63,29 @@ export const getStaticProps: GetStaticProps = async () => {
     { href: '/sitemap.xml', label: 'Sitemap XML' },
   ];
 
+  // === ✅ Fetch Shopify pages ===
+  const pagesQuery = `
+    {
+      pages(first: 100) {
+        edges {
+          node {
+            handle
+            title
+          }
+        }
+      }
+    }
+  `;
+  const pagesData = await shopifyFetch({ query: pagesQuery });
+  const pageLinks: PageLink[] =
+    pagesData.pages.edges.map(
+      ({ node }: { node: { handle: string; title: string } }) => ({
+        href: `/information/${node.handle}`,
+        label: node.title,
+      })
+    ) || [];
+  staticLinks.push(...pageLinks);
+
   const blogDir = path.join(process.cwd(), 'content/piercing-magazine');
   const blogFiles = fs.existsSync(blogDir) ? fs.readdirSync(blogDir) : [];
 


### PR DESCRIPTION
## Summary
- extend sitemap page to pull Shopify CMS pages and include them in static links
- generate `/information/<handle>` URLs in sitemap script

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: React hook and TypeScript errors)*
- `npm run sitemap` *(fails: fetch failed, missing Shopify config)*

------
https://chatgpt.com/codex/tasks/task_e_68b060008bdc8328b04d8e11585cd1d7