### PR TITLE
Add markdown-driven information pages

### DIFF
--- a/content/information/terms-of-sale.md
+++ b/content/information/terms-of-sale.md
@@ -1,0 +1,9 @@
+---
+title: Terms of Sale
+description: Example terms and conditions for purchases.
+---
+
+## Terms of Sale
+
+This is a sample terms of sale page written in markdown.
+

--- a/src/pages/information/[slug].tsx
+++ b/src/pages/information/[slug].tsx
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { marked } from 'marked';
+import Seo from '@/components/Seo';
+import type { GetStaticPaths, GetStaticProps } from 'next';
+
+interface InfoPageProps {
+  title: string;
+  description?: string;
+  content: string;
+  slug: string;
+}
+
+export default function InformationPage({ title, description, content, slug }: InfoPageProps) {
+  return (
+    <main className="info-page">
+      <Seo
+        title={title}
+        description={description || ''}
+        canonical={`https://www.auricle.co.uk/information/${slug}`}
+      />
+      <h1>{title}</h1>
+      <div dangerouslySetInnerHTML={{ __html: content }} />
+    </main>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const dir = path.join(process.cwd(), 'content/information');
+  const files = fs.readdirSync(dir);
+  const paths = files.map((file) => ({
+    params: { slug: file.replace(/\.md$/, '') },
+  }));
+  return { paths, fallback: false };
+};
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const slug = params?.slug as string;
+  const file = fs.readFileSync(
+    path.join(process.cwd(), 'content/information', `${slug}.md`),
+    'utf8'
+  );
+  const { data, content } = matter(file);
+
+  return {
+    props: {
+      title: data.title || slug,
+      description: data.description || null,
+      content: marked.parse(content),
+      slug,
+    },
+  };
+};
+

--- a/src/pages/information/index.tsx
+++ b/src/pages/information/index.tsx
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import Link from 'next/link';
+import Seo from '@/components/Seo';
+
+interface InfoPreview {
+  slug: string;
+  title: string;
+  description: string;
+}
+
+export default function InformationIndex({ pages }: { pages: InfoPreview[] }) {
+  return (
+    <main className="information-index">
+      <Seo title="Information" description="Important information pages." />
+      <h1>Information</h1>
+      <ul>
+        {pages.map(({ slug, title, description }) => (
+          <li key={slug}>
+            <Link href={`/information/${slug}`}>{title}</Link>
+            {description && <p>{description}</p>}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+export async function getStaticProps() {
+  const dir = path.join(process.cwd(), 'content/information');
+  const files = fs.readdirSync(dir);
+
+  const pages = files.map((filename) => {
+    const slug = filename.replace(/\.md$/, '');
+    const file = fs.readFileSync(path.join(dir, filename), 'utf8');
+    const { data } = matter(file);
+
+    return {
+      slug,
+      title: data.title || slug,
+      description: data.description || '',
+    };
+  });
+
+  return {
+    props: {
+      pages,
+    },
+  };
+}
+


### PR DESCRIPTION
## Summary
- render information pages from markdown files
- provide sample terms of sale content

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b06a264c80832882fdad60a3674956