### PR TITLE
fix: correct internal links for information pages

### DIFF
--- a/content/information/accessability-statement.md
+++ b/content/information/accessability-statement.md
@@ -24,7 +24,7 @@ This statement covers:
 - **Shopify Checkout** (hosted on a separate Shopify domain)
 - Third-party integrations used within our purchase flow, including **DHL** and **Royal Mail** (for shipping rate/label/tracking), and our **live chat** powered by the **ChatGPT API**
 
-Website use is governed by our [TERMS OF SERVICE](/terms-of-service). For personal data and cookies, see our [PRIVACY POLICY](/privacy-policy) and [COOKIE POLICY](/cookie-policy).
+Website use is governed by our [TERMS OF SERVICE](/information/terms-of-service). For personal data and cookies, see our [PRIVACY POLICY](/information/privacy-policy) and [COOKIE POLICY](/information/cookie-policy).
 
 ---
 
@@ -80,7 +80,7 @@ We currently do **not** offer general PDF downloads. **Invoice PDFs** may be iss
 
 ## 8. COOKIES
 
-Cookies are required for core functionality (authentication, cart, checkout). We do **not** provide per-category cookie settings. You may accept cookies to use the website, or decline by not using the website. See the [COOKIE POLICY](/cookie-policy).
+Cookies are required for core functionality (authentication, cart, checkout). We do **not** provide per-category cookie settings. You may accept cookies to use the website, or decline by not using the website. See the [COOKIE POLICY](/information/cookie-policy).
 
 ---
 

--- a/content/information/authorised-seller-map-policy.md
+++ b/content/information/authorised-seller-map-policy.md
@@ -9,7 +9,7 @@ robots: index,follow
 
 **Effective Date:** 9 August 2025
 
-> **NON-NEGOTIABLE POLICY:** Authorisation to resell AURICLE products and to use our brand assets requires compliance with this policy, including our **Minimum Advertised Price (MAP)** rules. If you do not agree, do not resell AURICLE products. See also [TERMS OF SALE](/terms-of-sale), [TERMS OF SERVICE](/terms-of-service) and [DESIGNS & IP](/designs-and-ip).
+> **NON-NEGOTIABLE POLICY:** Authorisation to resell AURICLE products and to use our brand assets requires compliance with this policy, including our **Minimum Advertised Price (MAP)** rules. If you do not agree, do not resell AURICLE products. See also [TERMS OF SALE](/information/terms-of-sale), [TERMS OF SERVICE](/information/terms-of-service) and [DESIGNS & IP](/information/design-copyright-ip-notice).
 
 ---
 
@@ -68,7 +68,7 @@ This policy concerns **advertised** price only. **Actual transactional sale pric
 
 ## 7. BRAND ASSETS & CONTENT
 
-Use of AURICLE images, copy and logos is subject to [DESIGNS & IP](/designs-and-ip). We may **withdraw the image/content licence** and request takedown for MAP breaches or brand misuse.
+Use of AURICLE images, copy and logos is subject to [DESIGNS & IP](/information/design-copyright-ip-notice). We may **withdraw the image/content licence** and request takedown for MAP breaches or brand misuse.
 
 ---
 
@@ -93,8 +93,8 @@ Nothing in this policy requires you to sell at any particular price. It governs 
 ## 10. QUESTIONS & NOTICES
 
 Policy enquiries: **info@auricle.co.uk**  
-Company details: [COMPANY INFORMATION](/company-information)  
-Formal notices: [COMPLAINTS & NOTICES](/complaints-and-notices)
+Company details: [COMPANY INFORMATION](/information/company-information-imprint)
+Formal notices: [COMPLAINTS & NOTICES](/information/complaints-notices)
 
 ---
 

--- a/content/information/company-information-imprint.md
+++ b/content/information/company-information-imprint.md
@@ -26,7 +26,7 @@ Websites: [www.auricle.co.uk](https://www.auricle.co.uk) · [www.auriclejewelry.
 
 **8 Silver Walk, Leicester, LE1 5EW, England**
 
-> This is our statutory registered office. Returns are **not** accepted at this address. For returns, please follow the RMA process in the [RETURNS POLICY](/returns-policy).
+> This is our statutory registered office. Returns are **not** accepted at this address. For returns, please follow the RMA process in the [RETURNS POLICY](/information/returns-and-faulty-goods-policy).
 
 ---
 
@@ -34,8 +34,8 @@ Websites: [www.auricle.co.uk](https://www.auricle.co.uk) · [www.auriclejewelry.
 
 **PO BOX 11129, Leicester, LE19 9EA, United Kingdom**
 
-General enquiries: **info@auricle.co.uk**  
-Formal notices: see [COMPLAINTS & NOTICES](/complaints-and-notices)
+General enquiries: **info@auricle.co.uk**
+Formal notices: see [COMPLAINTS & NOTICES](/information/complaints-notices)
 
 ---
 
@@ -43,19 +43,19 @@ Formal notices: see [COMPLAINTS & NOTICES](/complaints-and-notices)
 
 AURICLE operates a **B2B wholesale** platform for professional studios, jewellers, and authorised trade customers.
 
-Website use: [TERMS OF SERVICE](/terms-of-service)  
-Purchasing: [TERMS OF SALE](/terms-of-sale)
+Website use: [TERMS OF SERVICE](/information/terms-of-service)
+Purchasing: [TERMS OF SALE](/information/terms-of-sale)
 
 ---
 
 ## POLICIES & COMPLIANCE
 
-- Privacy: [PRIVACY POLICY](/privacy-policy)  
-- Cookies: [COOKIE POLICY](/cookie-policy)  
-- Shipping: [SHIPPING & DELIVERY POLICY](/shipping-policy)  
-- Returns (B2B): [RETURNS / FAULTY GOODS POLICY](/returns-policy)  
-- Tax / VAT: [TAX / VAT POLICY](/tax-policy)  
-- Designs & IP: [DESIGNS & IP](/designs-and-ip)
+- Privacy: [PRIVACY POLICY](/information/privacy-policy)
+- Cookies: [COOKIE POLICY](/information/cookie-policy)
+- Shipping: [SHIPPING & DELIVERY POLICY](/information/shipping-and-delivery-policy)
+- Returns (B2B): [RETURNS / FAULTY GOODS POLICY](/information/returns-and-faulty-goods-policy)
+- Tax / VAT: [TAX / VAT POLICY](/information/tax-vat-policy)
+- Designs & IP: [DESIGNS & IP](/information/design-copyright-ip-notice)
 
 ---
 

--- a/content/information/complaints-notices.md
+++ b/content/information/complaints-notices.md
@@ -9,7 +9,7 @@ robots: index,follow
 
 **Effective Date:** 9 August 2025
 
-> **FORMAL NOTICE REQUIREMENT:** Legal notices to AURICLE must be sent **only** as set out in this policy. Notices sent by other means (e.g., social media, live chat) may be **deemed not received**. See also the [TERMS OF SERVICE](/terms-of-service) and [TERMS OF SALE](/terms-of-sale).
+> **FORMAL NOTICE REQUIREMENT:** Legal notices to AURICLE must be sent **only** as set out in this policy. Notices sent by other means (e.g., social media, live chat) may be **deemed not received**. See also the [TERMS OF SERVICE](/information/terms-of-service) and [TERMS OF SALE](/information/terms-of-sale).
 
 ---
 
@@ -17,8 +17,8 @@ robots: index,follow
 
 This policy applies to **auricle.co.uk**, **auriclejewelry.com**, and our Shopify-hosted checkout. It applies to trade customers, suppliers, and other parties interacting with AURICLE.
 
-For privacy rights requests, see the [PRIVACY POLICY](/privacy-policy).  
-For accessibility feedback, see the [ACCESSIBILITY STATEMENT](/accessibility-statement).
+For privacy rights requests, see the [PRIVACY POLICY](/information/privacy-policy).
+For accessibility feedback, see the [ACCESSIBILITY STATEMENT](/information/accessability-statement).
 
 ---
 
@@ -41,10 +41,10 @@ If the issue remains unresolved, request a **final review**. We will provide our
 
 > Target response times: we aim to acknowledge within **5 business days**. Complex cases may take longer depending on investigation and carrier/vendor responses.
 
-- **Faulty goods or delivery problems:** follow the timelines and evidence requirements in the [RETURNS / FAULTY GOODS POLICY (B2B)](/returns-policy).  
-- **Shipping issues:** see the [SHIPPING & DELIVERY POLICY](/shipping-policy).  
-- **Designs/IP concerns:** see [DESIGNS & IP](/designs-and-ip).  
-- **Modern slavery concerns:** see the [MODERN SLAVERY STATEMENT](/modern-slavery-statement).
+- **Faulty goods or delivery problems:** follow the timelines and evidence requirements in the [RETURNS / FAULTY GOODS POLICY (B2B)](/information/returns-and-faulty-goods-policy).
+- **Shipping issues:** see the [SHIPPING & DELIVERY POLICY](/information/shipping-and-delivery-policy).
+- **Designs/IP concerns:** see [DESIGNS & IP](/information/design-copyright-ip-notice).
+- **Modern slavery concerns:** see the [MODERN SLAVERY STATEMENT](/information/modern-slavery-statement).
 
 ---
 
@@ -104,14 +104,14 @@ We do **not** accept legal notices via: social media, live chat (including ChatG
 
 ## 7. LAW & JURISDICTION
 
-This policy forms part of our contractual documentation and is governed by the laws of **England and Wales**. The courts of **England and Wales** have exclusive jurisdiction over disputes, as set out in the [TERMS OF SERVICE](/terms-of-service) and [TERMS OF SALE](/terms-of-sale).
+This policy forms part of our contractual documentation and is governed by the laws of **England and Wales**. The courts of **England and Wales** have exclusive jurisdiction over disputes, as set out in the [TERMS OF SERVICE](/information/terms-of-service) and [TERMS OF SALE](/information/terms-of-sale).
 
 ---
 
 ## 8. CONTACT & COMPANY DETAILS
 
-General enquiries and complaints: **info@auricle.co.uk**  
-Company details (legal name, VAT number): see [COMPANY INFORMATION / IMPRINT](/company-information).
+General enquiries and complaints: **info@auricle.co.uk**
+Company details (legal name, VAT number): see [COMPANY INFORMATION / IMPRINT](/information/company-information-imprint).
 
 ---
 

--- a/content/information/cookie-policy.md
+++ b/content/information/cookie-policy.md
@@ -10,7 +10,7 @@ robots: index,follow
 
 **Effective Date:** 9 August 2025
 
-This Cookie Policy explains how AURICLE Limited (“AURICLE”, “we”, “us”) uses cookies and similar technologies on [www.auricle.co.uk](https://www.auricle.co.uk) and [www.auriclejewelry.com](https://www.auriclejewelry.com) (“Website”). For how we process personal data, see our [Privacy Policy](/privacy-policy).
+This Cookie Policy explains how AURICLE Limited (“AURICLE”, “we”, “us”) uses cookies and similar technologies on [www.auricle.co.uk](https://www.auricle.co.uk) and [www.auriclejewelry.com](https://www.auriclejewelry.com) (“Website”). For how we process personal data, see our [Privacy Policy](/information/privacy-policy).
 
 > **Consent model:** To use this Website and our services, you must accept our use of cookies as described below. We do **not** offer per-category cookie settings. You can either **accept** cookies to use the Website or **decline** and not use the Website. You may also block cookies via your browser; however, the Website and checkout services may not function correctly without cookies.
 
@@ -66,8 +66,8 @@ We may update this Cookie Policy from time to time. Changes take effect when pos
 
 ## 6) CONTACT
 
-Questions about cookies? Contact **info@auricle.co.uk**.  
-For company details, see [Company Information](/company-information).
+Questions about cookies? Contact **info@auricle.co.uk**.
+For company details, see [Company Information](/information/company-information-imprint).
 
 ---
 

--- a/content/information/design-copyright-ip-notice.md
+++ b/content/information/design-copyright-ip-notice.md
@@ -9,7 +9,7 @@ robots: index,follow
 
 **Effective Date:** 9 August 2025
 
-> **NON-NEGOTIABLE TERMS:** Use of AURICLE designs, images, and brand assets is restricted as set out here. If you do not agree, do not use or reproduce our materials. See also the [TERMS OF SERVICE](/terms-of-service) and [TERMS OF SALE](/terms-of-sale).
+> **NON-NEGOTIABLE TERMS:** Use of AURICLE designs, images, and brand assets is restricted as set out here. If you do not agree, do not use or reproduce our materials. See also the [TERMS OF SERVICE](/information/terms-of-service) and [TERMS OF SALE](/information/terms-of-sale).
 
 ---
 
@@ -112,8 +112,8 @@ We reserve all remedies for infringement, including injunctive relief, damages, 
 
 We may update this notice from time to time. This notice is governed by the laws of **England and Wales**; courts of England and Wales have exclusive jurisdiction.
 
-Company details: see [COMPANY INFORMATION](/company-information).  
-Formal notices: see [COMPLAINTS & NOTICES](/complaints-and-notices).
+Company details: see [COMPANY INFORMATION](/information/company-information-imprint).
+Formal notices: see [COMPLAINTS & NOTICES](/information/complaints-notices).
 
 ---
 

--- a/content/information/materials-hallmarking.md
+++ b/content/information/materials-hallmarking.md
@@ -9,7 +9,7 @@ robots: index,follow
 
 **Effective Date:** 9 August 2025
 
-> **INFORMATIONAL NOTICE:** Materials and markings are provided as described below and may not be customised. For purchasing terms, see the [TERMS OF SALE](/terms-of-sale). For intellectual property, see [DESIGNS & IP](/designs-and-ip).
+> **INFORMATIONAL NOTICE:** Materials and markings are provided as described below and may not be customised. For purchasing terms, see the [TERMS OF SALE](/information/terms-of-sale). For intellectual property, see [DESIGNS & IP](/information/design-copyright-ip-notice).
 
 ---
 
@@ -81,7 +81,7 @@ Titanium components are **not** hallmarked (not precious metal under UK law). Wh
 
 ## 5. COLOUR & DISPLAY DISCLAIMER
 
-Display characteristics vary by device and screen type. **Colour and finish in real life may differ** from on-screen images. See [SHIPPING & DELIVERY POLICY](/shipping-policy) and [RETURNS / FAULTY GOODS POLICY (B2B)](/returns-policy) for fulfilment and defect handling.
+Display characteristics vary by device and screen type. **Colour and finish in real life may differ** from on-screen images. See [SHIPPING & DELIVERY POLICY](/information/shipping-and-delivery-policy) and [RETURNS / FAULTY GOODS POLICY (B2B)](/information/returns-and-faulty-goods-policy) for fulfilment and defect handling.
 
 ---
 
@@ -94,8 +94,8 @@ Materials specifications and marking practices may be updated as manufacturing m
 ## 7. CONTACT
 
 Material or hallmarking enquiries: **info@auricle.co.uk**  
-Company details: [COMPANY INFORMATION](/company-information)  
-Terms: [TERMS OF SALE](/terms-of-sale) · [TERMS OF SERVICE](/terms-of-service)
+Company details: [COMPANY INFORMATION](/information/company-information-imprint)
+Terms: [TERMS OF SALE](/information/terms-of-sale) · [TERMS OF SERVICE](/information/terms-of-service)
 
 ---
 

--- a/content/information/modern-slavery-statement.md
+++ b/content/information/modern-slavery-statement.md
@@ -19,7 +19,7 @@ If you have concerns or information related to modern slavery connected to our b
 
 This statement covers **auricle.co.uk**, **auriclejewelry.com**, and our **Shopify Checkout** (hosted on Shopify). It applies to our B2B wholesale operations and to suppliers and contractors who provide goods or services to AURICLE.
 
-Website use is governed by our [TERMS OF SERVICE](/terms-of-service). Company details are on [COMPANY INFORMATION](/company-information).
+Website use is governed by our [TERMS OF SERVICE](/information/terms-of-service). Company details are on [COMPANY INFORMATION](/information/company-information-imprint).
 
 ---
 

--- a/content/information/privacy-policy.md
+++ b/content/information/privacy-policy.md
@@ -11,7 +11,7 @@ robots: index,follow
 
 This Privacy Policy describes how we collect, use, disclose and protect personal data when you use our websites and services. It applies to [www.auricle.co.uk](https://www.auricle.co.uk) and [www.auriclejewelry.com](https://www.auriclejewelry.com) (the “Website”).
 
-> **NOTICE:** This policy explains how we process personal data. Some processing is strictly necessary to operate the Website and fulfil orders (contract/legitimate interests). If you do not agree with this policy, do not use the Website or submit personal data. For cookies, see the [COOKIE POLICY](/cookie-policy). Website use is governed by the [TERMS OF SERVICE](/terms-of-service).
+> **NOTICE:** This policy explains how we process personal data. Some processing is strictly necessary to operate the Website and fulfil orders (contract/legitimate interests). If you do not agree with this policy, do not use the Website or submit personal data. For cookies, see the [COOKIE POLICY](/information/cookie-policy). Website use is governed by the [TERMS OF SERVICE](/information/terms-of-service).
 ---
 
 ## 1) Who we are (Controller)
@@ -20,7 +20,7 @@ This Privacy Policy describes how we collect, use, disclose and protect personal
 We are the data **controller** for personal data processed through the Website and our B2B operations.
 
 Contact: **info@auricle.co.uk**  
-See our registered details on the [Company Information](/information/company) page.
+See our registered details on the [Company Information](/information/company-information-imprint) page.
 
 ---
 
@@ -29,7 +29,7 @@ See our registered details on the [Company Information](/information/company) pa
 - This is a **B2B** platform intended for legitimate businesses (studios, jewellers, distributors).  
 - Use of the Website is governed by our [Terms of Service](/information/terms-of-service).  
 - Purchasing is governed by our [Terms of Sale](/information/terms-of-sale).  
-- Cookies are explained in our [Cookie Policy](/information/cookies) and can be managed via [Cookie Preferences](/information/cookie-preferences).
+- Cookies are explained in our [Cookie Policy](/information/cookie-policy) and can be managed via [Cookie Preferences](/information/cookie-preferences).
 
 If you are under 18, you may only use the Website with parent/guardian consent.
 
@@ -44,7 +44,7 @@ We collect the following categories of personal data:
 - **Order & support**: orders, invoices, returns, messages to our team.  
 - **Usage & device**: IP address, device/browser info, pages viewed, referral source, approximate location (derived from IP).  
 - **Marketing preferences**: newsletter/artwork updates, opt-ins/opt-outs.  
-- **Cookies & similar tech**: see [Cookie Policy](/information/cookies).
+- **Cookies & similar tech**: see [Cookie Policy](/information/cookie-policy).
 
 We do **not** store full payment card numbers on our Website. Card data is handled by our checkout/payment provider.
 
@@ -138,7 +138,7 @@ Our Website and services are not directed to children. If you believe we have co
 ## 12) Cookies & similar technologies
 
 We use cookies and similar technologies for essential functions, performance, and (where enabled) analytics/marketing.  
-See our [Cookie Policy](/information/cookies) and manage choices via [Cookie Preferences](/information/cookie-preferences).
+See our [Cookie Policy](/information/cookie-policy) and manage choices via [Cookie Preferences](/information/cookie-preferences).
 
 ---
 
@@ -151,7 +151,7 @@ We may update this Privacy Policy from time to time. Changes take effect when po
 ## 14) Contact
 
 For privacy requests and questions: **info@auricle.co.uk**  
-Postal: see [Company Information](/information/company).
+Postal: see [Company Information](/information/company-information-imprint).
 
 ---
 

--- a/content/information/returns-and-faulty-goods-policy.md
+++ b/content/information/returns-and-faulty-goods-policy.md
@@ -9,13 +9,13 @@ robots: index,follow
 
 **Effective Date:** 9 August 2025
 
-> **NON-NEGOTIABLE POLICY (B2B):** Returns are accepted **only** for faulty goods as set out below. No change-of-mind returns are offered. If you do not agree, do not place an order. See also the [TERMS OF SALE](/terms-of-sale).
+> **NON-NEGOTIABLE POLICY (B2B):** Returns are accepted **only** for faulty goods as set out below. No change-of-mind returns are offered. If you do not agree, do not place an order. See also the [TERMS OF SALE](/information/terms-of-sale).
 
 ---
 
 ## 1. SCOPE
 
-This policy applies to B2B purchases from AURICLE. Website use is governed by the [TERMS OF SERVICE](/terms-of-service).
+This policy applies to B2B purchases from AURICLE. Website use is governed by the [TERMS OF SERVICE](/information/terms-of-service).
 
 ---
 
@@ -81,7 +81,7 @@ Email **info@auricle.co.uk** with:
 
 ## 9. GOVERNING LAW
 
-This policy forms part of the [TERMS OF SALE](/terms-of-sale) and is governed by the laws of England and Wales. Formal notices: see [COMPLAINTS & NOTICES](/complaints-and-notices).
+This policy forms part of the [TERMS OF SALE](/information/terms-of-sale) and is governed by the laws of England and Wales. Formal notices: see [COMPLAINTS & NOTICES](/information/complaints-notices).
 
 ---
 

--- a/content/information/shipping-and-delivery-policy.md
+++ b/content/information/shipping-and-delivery-policy.md
@@ -9,13 +9,13 @@ robots: index,follow
 
 **Effective Date:** 9 August 2025
 
-> **NON-NEGOTIABLE POLICY:** Shipping is provided only on the terms set out in this SHIPPING & DELIVERY POLICY. If you do not agree, do not place an order. See also the [TERMS OF SALE](/terms-of-sale).
+> **NON-NEGOTIABLE POLICY:** Shipping is provided only on the terms set out in this SHIPPING & DELIVERY POLICY. If you do not agree, do not place an order. See also the [TERMS OF SALE](/information/terms-of-sale).
 
 ---
 
 ## 1. SCOPE
 
-This policy applies to all orders placed with AURICLE via our website or by direct invoice. Website use is governed by the [TERMS OF SERVICE](/terms-of-service).
+This policy applies to all orders placed with AURICLE via our website or by direct invoice. Website use is governed by the [TERMS OF SERVICE](/information/terms-of-service).
 
 ---
 
@@ -38,9 +38,9 @@ Available services shown at checkout may vary by destination, order value, conte
 
 ## 4. DISPATCH & HANDLING
 
-- Orders are prepared and dispatched on **business days** (excluding UK public holidays).  
-- Verification steps (e.g., payment/anti-fraud, address confirmation) may affect dispatch timing.  
-- We may consolidate multiple items into a single shipment or split into partial shipments (see [TERMS OF SALE](/terms-of-sale)).
+- Orders are prepared and dispatched on **business days** (excluding UK public holidays).
+- Verification steps (e.g., payment/anti-fraud, address confirmation) may affect dispatch timing.
+- We may consolidate multiple items into a single shipment or split into partial shipments (see [TERMS OF SALE](/information/terms-of-sale)).
 
 ---
 
@@ -68,7 +68,7 @@ Available services shown at checkout may vary by destination, order value, conte
 - Customs inspections can add **unpredictable delays** that are outside our control.  
 - If you decline to pay import charges or cannot be contacted, the shipment may be returned or destroyed by the carrier. Any **return, storage, re-shipping, or destruction fees** are your responsibility.
 
-For VAT treatment and invoices, see the [TAX POLICY](/tax-policy).
+For VAT treatment and invoices, see the [TAX POLICY](/information/tax-vat-policy).
 
 ---
 
@@ -83,7 +83,7 @@ For VAT treatment and invoices, see the [TAX POLICY](/tax-policy).
 
 - **Risk** in the products passes to you **on delivery** to the address provided (or to your nominated carrier).  
 - **Title** passes when we receive **payment in full**, including all applicable delivery charges.  
-- See the [TERMS OF SALE](/terms-of-sale) for full details.
+- See the [TERMS OF SALE](/information/terms-of-sale) for full details.
 
 ---
 
@@ -93,7 +93,7 @@ For VAT treatment and invoices, see the [TAX POLICY](/tax-policy).
 - Report any visible damage, loss, or shortages to the **carrier at delivery** (where possible) and notify us **promptly** at **info@auricle.co.uk**.  
 - Keep all packaging and contents while a carrier investigation is in progress.
 
-For faulty product handling, see the [RETURNS POLICY](/returns-policy).
+For faulty product handling, see the [RETURNS POLICY](/information/returns-and-faulty-goods-policy).
 
 ---
 
@@ -119,8 +119,8 @@ We may update this policy from time to time. Changes take effect when posted on 
 ## 14. CONTACT
 
 Shipping enquiries: **info@auricle.co.uk**  
-Formal notices: see [COMPLAINTS & NOTICES](/complaints-and-notices).  
-Company details: see [COMPANY INFORMATION](/company-information).
+Formal notices: see [COMPLAINTS & NOTICES](/information/complaints-notices).
+Company details: see [COMPANY INFORMATION](/information/company-information-imprint).
 
 ---
 

--- a/content/information/subscriptions-recurring-billing.md
+++ b/content/information/subscriptions-recurring-billing.md
@@ -9,13 +9,13 @@ robots: index,follow
 
 **Effective Date:** 9 August 2025
 
-> **NON-NEGOTIABLE TERMS:** Subscribing authorises recurring charges as described below. We do not offer bespoke variations. If you do not agree, do not subscribe. See also the [TERMS OF SALE](/terms-of-sale), [TERMS OF SERVICE](/terms-of-service), [PRIVACY POLICY](/privacy-policy), and [COOKIE POLICY](/cookie-policy).
+> **NON-NEGOTIABLE TERMS:** Subscribing authorises recurring charges as described below. We do not offer bespoke variations. If you do not agree, do not subscribe. See also the [TERMS OF SALE](/information/terms-of-sale), [TERMS OF SERVICE](/information/terms-of-service), [PRIVACY POLICY](/information/privacy-policy), and [COOKIE POLICY](/information/cookie-policy).
 
 ---
 
 ## 1. SCOPE
 
-These terms apply to AURICLE subscription-based services offered to **B2B customers** via our websites or by direct invoice. Website use is governed by the [TERMS OF SERVICE](/terms-of-service).
+These terms apply to AURICLE subscription-based services offered to **B2B customers** via our websites or by direct invoice. Website use is governed by the [TERMS OF SERVICE](/information/terms-of-service).
 
 ---
 
@@ -29,9 +29,9 @@ Subscriptions are available to **legitimate businesses** (e.g., studios, jewelle
 
 - Subscriptions are **recurring** and billed **on the first day of each calendar month** according to your selected plan.  
 - By providing a payment method, you **authorise** AURICLE to charge the recurring fees automatically until you cancel.  
-- Fees are shown **before** you confirm enrollment and may be subject to taxes (see the [TAX / VAT POLICY](/tax-policy)).
+- Fees are shown **before** you confirm enrollment and may be subject to taxes (see the [TAX / VAT POLICY](/information/tax-vat-policy)).
 
-> Cookies are required for account, basket, and checkout features. We do **not** offer per-category cookie settings. Accept cookies to use the Website; otherwise, do not use the Website. See the [COOKIE POLICY](/cookie-policy).
+> Cookies are required for account, basket, and checkout features. We do **not** offer per-category cookie settings. Accept cookies to use the Website; otherwise, do not use the Website. See the [COOKIE POLICY](/information/cookie-policy).
 
 ---
 
@@ -73,7 +73,7 @@ Any benefits tied to a subscription (e.g., discounts, eligibility, gated access,
 
 ## 9. TAXES
 
-Charges may be subject to **VAT** or other taxes depending on your location and status. See the [TAX / VAT POLICY](/tax-policy). You are responsible for providing accurate tax identifiers where required.
+Charges may be subject to **VAT** or other taxes depending on your location and status. See the [TAX / VAT POLICY](/information/tax-vat-policy). You are responsible for providing accurate tax identifiers where required.
 
 ---
 
@@ -98,7 +98,7 @@ These terms (and any non-contractual disputes) are governed by the laws of **Eng
 ## 13. CONTACT
 
 Subscription enquiries and cancellations: **info@auricle.co.uk**  
-Company details: [COMPANY INFORMATION](/company-information)
+Company details: [COMPANY INFORMATION](/information/company-information-imprint)
 
 ---
 

--- a/content/information/tax-vat-policy.md
+++ b/content/information/tax-vat-policy.md
@@ -9,13 +9,13 @@ robots: index,follow
 
 **Effective Date:** 9 August 2025
 
-> **NON-NEGOTIABLE POLICY:** VAT treatment, export rules, and invoicing are applied as described in this TAX / VAT POLICY. If you do not agree, do not place an order. See also the [TERMS OF SALE](/terms-of-sale) and [SHIPPING & DELIVERY POLICY](/shipping-policy).
+> **NON-NEGOTIABLE POLICY:** VAT treatment, export rules, and invoicing are applied as described in this TAX / VAT POLICY. If you do not agree, do not place an order. See also the [TERMS OF SALE](/information/terms-of-sale) and [SHIPPING & DELIVERY POLICY](/information/shipping-and-delivery-policy).
 
 ---
 
 ## 1. SCOPE
 
-This policy applies to all B2B purchases from AURICLE via our website or direct invoice. Website use is governed by the [TERMS OF SERVICE](/terms-of-service).
+This policy applies to all B2B purchases from AURICLE via our website or direct invoice. Website use is governed by the [TERMS OF SERVICE](/information/terms-of-service).
 
 ---
 
@@ -42,7 +42,7 @@ This policy applies to all B2B purchases from AURICLE via our website or direct 
 - Under **DAP/DDU**, **import VAT, customs duties, brokerage/clearance fees, and local taxes are payable by you** to the carrier or your local authority.  
 - If you refuse or fail to pay import charges, the shipment may be **returned or destroyed** by the carrier. Any return, storage, re-shipping, or destruction fees are **your responsibility**.
 
-See the [SHIPPING & DELIVERY POLICY](/shipping-policy) for carrier details.
+See the [SHIPPING & DELIVERY POLICY](/information/shipping-and-delivery-policy) for carrier details.
 
 ---
 
@@ -97,8 +97,8 @@ We may update this policy from time to time. Changes take effect when posted on 
 ## 12. CONTACT
 
 Tax/VAT enquiries: **info@auricle.co.uk**  
-Company details: see [COMPANY INFORMATION](/company-information).  
-Formal notices: see [COMPLAINTS & NOTICES](/complaints-and-notices).
+Company details: see [COMPANY INFORMATION](/information/company-information-imprint).
+Formal notices: see [COMPLAINTS & NOTICES](/information/complaints-notices).
 
 ---
 

--- a/content/information/terms-of-sale.md
+++ b/content/information/terms-of-sale.md
@@ -11,16 +11,16 @@ robots: index,follow
 
 These Terms of Sale apply to wholesale purchases made from AURICLE via our websites or by direct invoice. They set out how orders are placed, paid for, delivered, and handled if something goes wrong.
 
-> **NON-NEGOTIABLE TERMS:** Placing an order requires acceptance of these TERMS OF SALE in full. We do not offer bespoke variations. If you do not agree, do not place an order. See also the [SHIPPING POLICY](/shipping-policy), [RETURNS POLICY](/returns-policy) and [TAX POLICY](/tax-policy).
+> **NON-NEGOTIABLE TERMS:** Placing an order requires acceptance of these TERMS OF SALE in full. We do not offer bespoke variations. If you do not agree, do not place an order. See also the [SHIPPING POLICY](/information/shipping-and-delivery-policy), [RETURNS POLICY](/information/returns-and-faulty-goods-policy) and [TAX POLICY](/information/tax-vat-policy).
 
 ---
 
 ## 1. Scope
 
 - These terms govern **wholesale (B2B)** sales only.  
-- Website use is covered by the [Terms of Service](/information/terms-of-service).  
-- Privacy and cookies are covered by our [Privacy Policy](/information/privacy) and [Cookie Policy](/information/cookies).  
-- Subscriptions (auto-replenish) are covered by the [Subscriptions & Recurring Billing](/information/subscriptions) terms.
+- Website use is covered by the [Terms of Service](/information/terms-of-service).
+- Privacy and cookies are covered by our [Privacy Policy](/information/privacy-policy) and [Cookie Policy](/information/cookie-policy).
+- Subscriptions (auto-replenish) are covered by the [Subscriptions & Recurring Billing](/information/subscriptions-recurring-billing) terms.
 
 ---
 
@@ -49,7 +49,7 @@ These Terms of Sale apply to wholesale purchases made from AURICLE via our websi
 - For deliveries outside the UK, VAT is deducted at checkout when a valid export address is provided.  
 - USD/EUR prices shown (if any) are **approximate**; your card provider sets the actual exchange rate.
 
-For detailed tax treatment, see [Tax & VAT Policy](/information/tax-vat).
+For detailed tax treatment, see [Tax & VAT Policy](/information/tax-vat-policy).
 
 ---
 
@@ -70,7 +70,7 @@ For detailed tax treatment, see [Tax & VAT Policy](/information/tax-vat).
 - If the country selected at checkout does not match the delivery address, we may **cancel** the order.  
 - For security, we may ship to the **card billing address**.
 
-For carrier details, restrictions, and current timelines see the [Shipping Policy](/information/shipping).
+For carrier details, restrictions, and current timelines see the [Shipping Policy](/information/shipping-and-delivery-policy).
 
 ---
 
@@ -98,7 +98,7 @@ For carrier details, restrictions, and current timelines see the [Shipping Polic
 - Returns for change of mind, over-ordering, or compatibility are **not accepted**.  
 - Our returns policy does not affect your **statutory rights**.
 
-For process steps and packaging instructions, see the [Returns Policy](/information/returns).
+For process steps and packaging instructions, see the [Returns Policy](/information/returns-and-faulty-goods-policy).
 
 ---
 
@@ -108,7 +108,7 @@ For process steps and packaging instructions, see the [Returns Policy](/informat
 - Drawings, photos, specifications, and advertising are **approximate** and do not form part of the contract.  
 - We may improve or amend specifications where this does not materially affect performance or quality.
 
-For design rights and usage, see [Designs & IP](/information/ip).
+For design rights and usage, see [Designs & IP](/information/design-copyright-ip-notice).
 
 ---
 
@@ -150,14 +150,14 @@ For design rights and usage, see [Designs & IP](/information/ip).
 
 ## 16. Notices & Contact
 
-Formal notices and complaints are handled as described on our [Complaints & Notices](/information/complaints) page.  
+Formal notices and complaints are handled as described on our [Complaints & Notices](/information/complaints-notices) page.
 General contact: **info@auricle.co.uk**.
 
 ---
 
 ## 17. Company Information
 
-AURICLE is a trading style of **AURICLE Limited**. See our [Company Information](/information/company) page for registered details.
+AURICLE is a trading style of **AURICLE Limited**. See our [Company Information](/information/company-information-imprint) page for registered details.
 
 ---
 

--- a/content/information/terms-of-service.md
+++ b/content/information/terms-of-service.md
@@ -11,13 +11,13 @@ robots: index,follow
 
 These Terms of Service set out the rules for using our websites and online services. By accessing or using the site, you agree to these terms.
 
-> **NON-NEGOTIABLE TERMS:** Use of the Website requires acceptance of these TERMS OF SERVICE in full. We do not offer bespoke variations. If you do not agree, do not use the Website. See also the [PRIVACY POLICY](/privacy-policy) and [COOKIE POLICY](/cookie-policy).
+> **NON-NEGOTIABLE TERMS:** Use of the Website requires acceptance of these TERMS OF SERVICE in full. We do not offer bespoke variations. If you do not agree, do not use the Website. See also the [PRIVACY POLICY](/information/privacy-policy) and [COOKIE POLICY](/information/cookie-policy).
 
 ---
 
 ## 1. Who we are
 
-“AURICLE”, “we”, “us” and “our” refer to **AURICLE Limited**. Details are provided on our [Company Information](/information/company) page.
+“AURICLE”, “we”, “us” and “our” refer to **AURICLE Limited**. Details are provided on our [Company Information](/information/company-information-imprint) page.
 
 “You” means the person or entity using the website.
 
@@ -29,8 +29,8 @@ This website is operated as a **B2B** platform and is not intended for consumer 
 
 ## 2. Other terms that apply
 
-These terms cover **use of the website only**. When you buy products, the [Terms of Sale](/information/terms-of-sale) apply.  
-How we handle personal data is explained in our [Privacy Policy](/information/privacy) and our use of cookies in the [Cookie Policy](/information/cookies). Specific IP notices are in our [Designs & IP](/information/ip).
+These terms cover **use of the website only**. When you buy products, the [Terms of Sale](/information/terms-of-sale) apply.
+How we handle personal data is explained in our [Privacy Policy](/information/privacy-policy) and our use of cookies in the [Cookie Policy](/information/cookie-policy). Specific IP notices are in our [Designs & IP](/information/design-copyright-ip-notice).
 
 ---
 
@@ -56,7 +56,7 @@ Some areas may require an account. You are responsible for keeping your credenti
 
 All content on the website (including text, graphics, images, logos, and code) is owned by or licensed to AURICLE and is protected by copyright and other IP rights. All rights are reserved.
 
-You may print or download extracts for your legitimate business use with us, provided you do not modify the material and retain any notices. Any other use requires our prior written permission. For design-specific notices, see [Designs & IP](/information/ip).
+You may print or download extracts for your legitimate business use with us, provided you do not modify the material and retain any notices. Any other use requires our prior written permission. For design-specific notices, see [Designs & IP](/information/design-copyright-ip-notice).
 
 If you submit content to us (e.g., reviews, testimonials), you grant us a non-exclusive, worldwide, royalty-free licence to use, reproduce and display that content in connection with the website and our business, and you confirm you have the necessary rights to grant this licence.
 
@@ -112,7 +112,7 @@ These terms (and any non-contractual disputes or claims) are governed by the law
 
 ## 13. Notices and contact
 
-For formal notices or complaints, see our [Complaints & Notices](/information/complaints) page.  
+For formal notices or complaints, see our [Complaints & Notices](/information/complaints-notices) page.
 General contact: **info@auricle.co.uk**.
 
 ---


### PR DESCRIPTION
## Summary
- fix internal markdown links for information pages to include `/information/<slug>` paths
- align link targets with actual file names (e.g., shipping-and-delivery-policy, company-information-imprint)

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: React Hook and type errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68b179ed16708328a3ec2a430f15b1e8