### PR TITLE
Check auth cookie before verifying session

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -40,6 +40,16 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
   const router = useRouter();
 
   const verifySession = async (): Promise<boolean> => {
+    const hasCookie = document.cookie
+      .split('; ')
+      .some((cookie) => cookie.startsWith(`${COOKIE_NAME}=`));
+
+    if (!hasCookie) {
+      setUser(null);
+      setIsAuthenticated(false);
+      return false;
+    }
+
     try {
       const res = await fetch('/api/shopify/verify-customer', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- Avoid redundant session verification requests by checking for the auth cookie first.
- Return early and reset auth state when the cookie is absent, maintaining existing behavior otherwise.

## Testing
- `npm test`
- `npm run lint` *(fails: React hooks called conditionally, no-unused-vars, no-explicit-any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b57cf59d1c8328937714f3b5a2b362