### PR TITLE
Validate customer sessions in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { COOKIE_NAME } from '@/lib/cookies'
+import { verifyCustomerSession } from '@/lib/verifyCustomerSession'
 
 // Regex for public static files like .js, .css, images, etc.
 const PUBLIC_FILE = /\.(?:js|css|png|jpg|jpeg|gif|svg|webp|ico)$/i
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
   // Skip Next.js internals and static assets
@@ -14,6 +16,20 @@ export function middleware(request: NextRequest) {
     PUBLIC_FILE.test(pathname)
   ) {
     return NextResponse.next()
+  }
+
+  const sessionCookie = request.cookies.get(COOKIE_NAME)?.value
+  if (sessionCookie) {
+    const customer = await verifyCustomerSession(sessionCookie)
+    if (customer) {
+      const requestHeaders = new Headers(request.headers)
+      requestHeaders.set('x-customer', JSON.stringify(customer))
+      return NextResponse.next({
+        request: {
+          headers: requestHeaders,
+        },
+      })
+    }
   }
 
   // Place custom middleware logic for dynamic pages here

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import type { AppProps } from 'next/app';
+import App, { type AppContext, type AppProps } from 'next/app';
 import Head from 'next/head';
 import dynamic from 'next/dynamic';
 
@@ -80,4 +80,18 @@ export default function MyApp({ Component, pageProps }: MyAppProps) {
       </AuthProvider>
     </ToastProvider>
   );
+}
+
+MyApp.getInitialProps = async (appContext: AppContext) => {
+  const appProps = await App.getInitialProps(appContext)
+  const customerHeader = appContext.ctx.req?.headers['x-customer']
+  if (customerHeader && typeof customerHeader === 'string') {
+    try {
+      appProps.pageProps = appProps.pageProps || {}
+      appProps.pageProps.customer = JSON.parse(customerHeader)
+    } catch {
+      // ignore parse errors
+    }
+  }
+  return appProps
 }


### PR DESCRIPTION
## Summary
- Verify session cookies in middleware and forward customer data via `x-customer` header
- Initialize `AuthProvider` with server-verified customer from middleware

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: repository-wide lint errors)*
- `npm run lint -- --file middleware.ts --file src/pages/_app.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b71bbee1c883288535c79a11e0b2a0