### PR TITLE
refactor: throttle auth session checks

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -81,16 +81,14 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
       return;
     }
 
-    const handleVisibility = () => {
-      if (document.visibilityState === 'visible') {
-        verifySession().finally(() => setLoading(false));
-      }
+    const checkSession = () => {
+      verifySession().finally(() => setLoading(false));
     };
 
-    document.addEventListener('visibilitychange', handleVisibility);
-    handleVisibility();
+    checkSession();
+    const intervalId = setInterval(verifySession, 60_000);
 
-    return () => document.removeEventListener('visibilitychange', handleVisibility);
+    return () => clearInterval(intervalId);
   }, [initialUser]);
 
 


### PR DESCRIPTION
## Summary
- avoid rapid API calls by replacing visibility change listener with periodic session checks

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: hooks called conditionally, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars)


------
https://chatgpt.com/codex/tasks/task_e_68b71bd4b5908328bf14fb641a687704