### PR TITLE
Remove explicit swcMinify from Next.js config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -69,7 +69,6 @@ const pwaConfig = withPWA({
 const nextConfig = {
   reactStrictMode: true,
   trailingSlash: false,
-  swcMinify: true, // safe: smaller JS
   compiler: {
     // safe: remove console.* in production except warn/error
     removeConsole:


### PR DESCRIPTION
## Summary
- remove `swcMinify` from Next.js config since it's enabled by default

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: react-hooks/rules-of-hooks, @typescript-eslint/no-explicit-any, @next/next/no-img-element, and more)*

------
https://chatgpt.com/codex/tasks/task_e_68b71fbf05388328b24e32ff23116cb8