### PR TITLE
Handle Shopify fetch failures

### DIFF
--- a/src/lib/shopify.ts
+++ b/src/lib/shopify.ts
@@ -5,18 +5,28 @@ export async function shopifyFetch({
   query,
   variables = {},
 }: { query: string; variables?: Record<string, unknown> }) {
+  try {
+    const res = await fetch(`https://${domain}/api/2024-04/graphql.json`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Shopify-Storefront-Access-Token': token,
+      },
+      body: JSON.stringify({ query, variables }),
+    });
 
+    if (!res.ok) {
+      throw new Error(`Shopify API error: ${res.status} ${res.statusText}`);
+    }
 
-  const res = await fetch(`https://${domain}/api/2024-04/graphql.json`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Shopify-Storefront-Access-Token': token,
-    },
-    body: JSON.stringify({ query, variables }),
-  });
-
-  const json = await res.json();
-  if (json.errors) throw new Error(JSON.stringify(json.errors));
-  return json.data;
+    const json = await res.json();
+    if (json.errors) throw new Error(JSON.stringify(json.errors));
+    return json.data;
+  } catch (error) {
+    throw new Error(
+      `Shopify fetch failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- wrap Shopify `fetch` in try/catch and surface more helpful errors

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: React Hook called conditionally; Unexpected any)


------
https://chatgpt.com/codex/tasks/task_e_68b71fc2d6e88328811816179624e993