### PR TITLE
Display SKU for selected product variant

### DIFF
--- a/src/pages/product/[handle].tsx
+++ b/src/pages/product/[handle].tsx
@@ -40,11 +40,12 @@ interface ProductVariantNode {
     amount: string;
   };
   availableForSale: boolean;
-  quantityAvailable: number; 
+  quantityAvailable: number;
   selectedOptions: {
     name: string;
     value: string;
   }[];
+  sku: string;
 }
 
 interface Product {
@@ -203,6 +204,8 @@ const [qty, setQty] = useState(0);
     }
   };
 
+  const selectedSku = selectedVariant?.sku || getFieldValue('sku');
+
   const currentVariantLabel = getFieldValue('variant_label') || 'Select an option';
   const rawVariants = getFieldValue('variants');
 
@@ -353,6 +356,19 @@ const [qty, setQty] = useState(0);
 
           <div className="product-info">
             <h1 style={{ fontSize: '20px', fontWeight: 600, marginBottom: '4px' }}>{product.title}</h1>
+            {selectedSku && (
+              <p
+                style={{
+                  fontSize: '12px',
+                  color: '#888',
+                  marginTop: '10px',
+                  marginBottom: '16px',
+                  textAlign: 'right',
+                }}
+              >
+                {selectedSku}
+              </p>
+            )}
             {!loading && (user?.approved ? (
               <>
                 {/* Price */}
@@ -675,6 +691,7 @@ export const getStaticProps: GetStaticProps<ProductPageProps> = async (
             availableForSale
             quantityAvailable
             selectedOptions { name value }
+            sku
           }
         }
       }


### PR DESCRIPTION
## Summary
- extend `ProductVariantNode` with `sku`
- fetch variant `sku` in `getStaticProps` and expose selected SKU
- render SKU beneath product title

## Testing
- `yarn lint` *(fails: React Hook "useAccountValidationContext" is called conditionally, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7febbd3b88328a3ee11b9286975fe