### PR TITLE
Prevent CLS for favourite toggle on product page

### DIFF
--- a/src/pages/product/[handle].tsx
+++ b/src/pages/product/[handle].tsx
@@ -357,15 +357,19 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
           <div className="product-image" style={{ position: 'relative' }}>
             <ProductGallery images={galleryImages} />
 
-            {showFav && (
-              <FavouriteToggleLazy
-                handle={router.query.handle as string}
-                title={product.title}
-                image={galleryImages[0]?.url || '/placeholder.png'}
-                price={formattedPrice}
-                metafields={metafields}
-              />
-            )}
+            <div className="fav-wrapper">
+              {showFav ? (
+                <FavouriteToggleLazy
+                  handle={router.query.handle as string}
+                  title={product.title}
+                  image={galleryImages[0]?.url || '/placeholder.png'}
+                  price={formattedPrice}
+                  metafields={metafields}
+                />
+              ) : (
+                <span className="fav-placeholder" />
+              )}
+            </div>
           </div>
 
           <div className="product-info">

--- a/src/styles/pages/product.scss
+++ b/src/styles/pages/product.scss
@@ -104,15 +104,30 @@ input[type='number'] {
     border-color: #181818;
   }
 }
-.favourite-toggle {
+
+.fav-wrapper,
+.fav-placeholder {
   position: absolute;
   bottom: 12px;
   right: 12px;
+  width: 44px;
+  height: 44px;
+}
+
+.fav-wrapper {
+  z-index: 5;
+}
+
+.fav-wrapper .fav-placeholder {
+  bottom: 0;
+  right: 0;
+}
+
+.favourite-toggle {
   background: transparent;
   border: none;
   padding: 12px; // ← optional for larger touch target
   cursor: pointer;
-  z-index: 5;
 
   svg {
     transition: fill 0.2s ease;


### PR DESCRIPTION
## Summary
- wrap FavouriteToggle with persistent placeholder to avoid layout shift
- add absolute-positioned styles for new wrapper and placeholder

## Testing
- `yarn lint` *(fails: Unexpected any in unrelated files)*
- `yarn build` *(fails: Shopify fetch failed)*
- `npx lighthouse http://localhost:3000 --quiet --chrome-flags="--headless"` *(fails: 403 Forbidden downloading lighthouse package)*

------
https://chatgpt.com/codex/tasks/task_e_68b8175d3d9483289ffd98f394f50d4c