### PR TITLE
feat: maintain layout when loading StyledByYou

### DIFF
--- a/src/pages/product/[handle].tsx
+++ b/src/pages/product/[handle].tsx
@@ -709,8 +709,12 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
 </div>
 
         {/* ✅ Styled By You (renders when near viewport) */}
-        <div ref={sbyAnchorRef} />
-        {showSBY ? <StyledByYouLazy items={ugcItems} /> : null}
+        <div
+          ref={sbyAnchorRef}
+          style={{ minHeight: showSBY ? undefined : '400px' }}
+        >
+          {showSBY ? <StyledByYouLazy items={ugcItems} /> : null}
+        </div>
 
         <div style={{ height: '80px' }} />
         


### PR DESCRIPTION
## Summary
- add placeholder div with min-height before StyledByYou loads
- render StyledByYouLazy inside the placeholder to avoid layout shift

## Testing
- `yarn lint` *(fails: React Hooks used conditionally, unexpected any types, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b82d794fb08328a9f1de2e7caf3b14