### PR TITLE
Simplify price display on product page

### DIFF
--- a/src/pages/product/[handle].tsx
+++ b/src/pages/product/[handle].tsx
@@ -391,9 +391,8 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
     </p>
   )}
 
-  {/* Price (tri-state; no CLS) */}
-  <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end' }}>
+    {/* Price */}
+    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
       <div
         style={{
           width: '80px',
@@ -401,7 +400,6 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
           position: 'relative',
         }}
       >
-        {/* Final price */}
         <span
           aria-live="polite"
           style={{
@@ -418,52 +416,8 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
         >
           £{formattedPrice}
         </span>
-
-        {/* Skeleton while loading */}
-        <span
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%',
-            borderRadius: '4px',
-            background: '#eee',
-            visibility: approved === null ? 'visible' : 'hidden',
-            opacity: approved === null ? 1 : 0,
-            transition: 'opacity 0.2s ease',
-          }}
-        />
-
-        {/* Invisible placeholder for non-approved users */}
-        <span
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            fontSize: '14px',
-            fontWeight: 500,
-            lineHeight: '24px',
-            color: 'transparent',
-            visibility: approved === false ? 'visible' : 'hidden',
-            opacity: approved === false ? 1 : 0,
-            transition: 'opacity 0.2s ease',
-          }}
-        >
-          £{formattedPrice}
-        </span>
       </div>
-
-      {approved === false && (
-        <div style={{ marginTop: '4px', fontSize: '12px', textAlign: 'right' }}>
-          <span style={{ opacity: 0.6 }}>Sign in to view pricing</span>{' '}
-          <Link href="/sign-in" style={{ textDecoration: 'underline' }}>
-            Sign in
-          </Link>
-        </div>
-      )}
     </div>
-  </div>
 
   {/* Variant options (unchanged) */}
   {variantOptions.length > 0 && (


### PR DESCRIPTION
## Summary
- streamline price block with fixed-size container
- remove sign-in prompt under price area

## Testing
- `./node_modules/.bin/eslint src/pages/product/[handle].tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b8313b833883288e956f1c1a7824d7