### PR TITLE
Simplify sign-in label on product page

### DIFF
--- a/src/pages/product/[handle].tsx
+++ b/src/pages/product/[handle].tsx
@@ -609,7 +609,7 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
         disabled={approved !== true || isSoldOut}
         aria-disabled={approved !== true || isSoldOut}
       >
-        {approved !== true ? 'SIGN IN TO BUY' : (isSoldOut ? 'SOLD OUT' : 'ADD TO BAG')}
+        {approved !== true ? 'SIGN IN' : (isSoldOut ? 'SOLD OUT' : 'ADD TO BAG')}
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- replace "SIGN IN TO BUY" label with "SIGN IN" on product page add-to-cart button

## Testing
- `yarn test` *(fails: Command "test" not found)*
- `yarn lint` *(fails: multiple existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b8323fbf048328b5a0d4a267ba038a