### PR TITLE
fix: reserve SKU space

### DIFF
--- a/src/pages/product/[handle].tsx
+++ b/src/pages/product/[handle].tsx
@@ -377,19 +377,18 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
     {product.title}
   </h1>
 
-  {selectedSku && (
-    <p
-      style={{
-        fontSize: '12px',
-        color: '#666',
-        marginTop: '10px',
-        marginBottom: '16px',
-        textAlign: 'left',
-      }}
-    >
-      {selectedSku}
-    </p>
-  )}
+  <p
+    style={{
+      fontSize: '12px',
+      color: '#666',
+      marginTop: '10px',
+      marginBottom: '16px',
+      textAlign: 'left',
+      minHeight: 18,
+    }}
+  >
+    {selectedSku || ''}
+  </p>
 
     {/* Price */}
     <div style={{ display: 'flex', justifyContent: 'flex-end' }}>


### PR DESCRIPTION
## Summary
- prevent SKU layout shift on product page by always rendering a wrapper

## Testing
- `yarn lint` *(fails: React Hook useAccountValidationContext is called conditionally, several @typescript-eslint/no-explicit-any errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b833e8bd88832880eec8c6ecbf52e1