### PR TITLE
Fade and disable out-of-stock variant buttons

### DIFF
--- a/src/pages/product/[handle].tsx
+++ b/src/pages/product/[handle].tsx
@@ -474,19 +474,20 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
         {product.variants.edges.map(({ node }) => {
           const isSelected = selectedVariantId === node.id;
           const oos = !node.availableForSale || (node.quantityAvailable ?? 0) <= 0;
-          return (
-            <button
-              key={node.id}
-              onClick={() => setSelectedVariantId(node.id)}
-              className={`variant-button${isSelected ? ' selected' : ''}${oos ? ' is-disabled' : ''}`}
-              disabled={oos}
-              aria-disabled={oos}
-              title={oos ? 'Sold out' : undefined}
-            >
-              {node.title}
-            </button>
-          );
-        })}
+            return (
+              <button
+                key={node.id}
+                onClick={() => setSelectedVariantId(node.id)}
+                className={`variant-button${isSelected ? ' selected' : ''}${oos ? ' is-disabled' : ''}`}
+                disabled={oos}
+                aria-disabled={oos}
+                title={oos ? 'Sold out' : undefined}
+                aria-label={oos ? `${node.title} (Sold out)` : undefined}
+              >
+                {node.title}
+              </button>
+            );
+          })}
       </div>
     </div>
   )}

--- a/src/styles/pages/product.scss
+++ b/src/styles/pages/product.scss
@@ -105,6 +105,17 @@ input[type='number'] {
   }
 }
 
+.variant-button.is-disabled {
+  opacity: 0.5;
+  text-decoration: line-through;
+  cursor: not-allowed;
+  pointer-events: none;
+
+  &:hover {
+    opacity: 0.5;
+  }
+}
+
 .fav-wrapper,
 .fav-placeholder {
   position: absolute;


### PR DESCRIPTION
## Summary
- fade variant button and block interactions when out of stock
- add aria-label for sold out variants

## Testing
- `yarn lint` *(fails: React Hook "useAccountValidationContext" is called conditionally; ... etc)*
- `yarn lint --file src/pages/product/[handle].tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b837b4c6b88328ac90369fc857929d