### PR TITLE
feat: prioritize variant images in product gallery

### DIFF
--- a/src/components/ProductGallery.tsx
+++ b/src/components/ProductGallery.tsx
@@ -28,6 +28,8 @@ export default function ProductGallery({ images }: { images: GalleryImage[] }) {
   const [active, setActive] = useState(0);
   const isDesktop = useIsDesktop();
 
+  useEffect(() => setActive(0), [images]);
+
   const safeImages = useMemo(() => (images || []).filter(Boolean), [images]);
   if (!safeImages.length) return null;
 


### PR DESCRIPTION
## Summary
- fetch variant images in product query
- prepend selected variant image to product gallery and de-duplicate
- reset gallery to first image when image set changes

## Testing
- `yarn lint` *(fails: React hook, no-unused-vars, no-explicit-any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b87aa60cb08328a0ec95f825109a89