### PR TITLE
Deduplicate gallery images and tweak thumbnails

### DIFF
--- a/src/components/ProductGallery.tsx
+++ b/src/components/ProductGallery.tsx
@@ -69,12 +69,12 @@ export default function ProductGallery({ images }: { images: GalleryImage[] }) {
                 role="group" /* simpler ARIA; avoids tablist requirements */
                 aria-label="Product thumbnails"
               >
-                {safeImages.map((img, i) => (
+                {safeImages.slice(1).map((img, i) => (
                   <button
-                    key={img.url + i}
-                    aria-label={`Show image ${i + 1}`}
-                    className={`thumb ${i === active ? "is-active" : ""}`}
-                    onClick={() => setActive(i)}
+                    key={img.url + (i + 1)}
+                    aria-label={`Show image ${i + 2}`}
+                    className={`thumb ${i + 1 === active ? "is-active" : ""}`}
+                    onClick={() => setActive(i + 1)}
                     type="button"
                   >
                     <div className="thumb-frame">
@@ -88,7 +88,7 @@ export default function ProductGallery({ images }: { images: GalleryImage[] }) {
                         decoding="async"
                         fetchPriority="low"
                         sizes="60px"
-                        quality={40} 
+                        quality={40}
                       />
                     </div>
                   </button>

--- a/src/pages/product/[handle].tsx
+++ b/src/pages/product/[handle].tsx
@@ -171,14 +171,17 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
         }]
       : [];
 
+    const variantBase = selectedVariant?.image?.url.split("?")[0];
     const official: GalleryImage[] =
-      (product.images?.edges || []).map(({ node }) => ({
-        url: node.url,
-        width: node.width,
-        height: node.height,
-        alt: node.altText || product.title,
-        isUGC: false,
-      }));
+      (product.images?.edges || [])
+        .filter(({ node }) => node.url.split("?")[0] !== variantBase)
+        .map(({ node }) => ({
+          url: node.url,
+          width: node.width,
+          height: node.height,
+          alt: node.altText || product.title,
+          isUGC: false,
+        }));
 
     const sby: GalleryImage[] = (ugcItems || []).slice(0, 2).map((it) => ({
       url: it.image.url,
@@ -189,11 +192,12 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
       credit: it.credit || undefined,
     }));
 
-    // De-dupe by URL, preserving order
+    // De-dupe by base URL, preserving order
     const seen = new Set<string>();
     return [...variantImg, ...official, ...sby].filter((img) => {
-      if (seen.has(img.url)) return false;
-      seen.add(img.url);
+      const base = img.url.split("?")[0];
+      if (seen.has(base)) return false;
+      seen.add(base);
       return true;
     });
   }, [product.images, product.title, ugcItems, selectedVariant?.image, selectedVariant?.image?.url]);


### PR DESCRIPTION
## Summary
- filter product images that match the selected variant
- dedupe gallery images by base URL
- skip first image in desktop thumbnails and fix indices

## Testing
- `yarn lint` *(fails: React Hook useAccountValidationContext is called conditionally and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b87dcaef208328a0518b74c51ed5fa