### PR TITLE
Limit gallery to single non-variant product image

### DIFF
--- a/src/pages/product/[handle].tsx
+++ b/src/pages/product/[handle].tsx
@@ -161,6 +161,12 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
   // Build the combined gallery: selected variant image first (if any),
   // followed by product images and up to 2 “Styled By You” images
   const galleryImages = useMemo<GalleryImage[]>(() => {
+    const variantImages = new Set(
+      variantEdges
+        .map(({ node }) => node.image?.url.split("?")[0])
+        .filter((u): u is string => Boolean(u))
+    );
+
     const variantImg: GalleryImage[] = selectedVariant?.image
       ? [{
           url: selectedVariant.image.url,
@@ -171,10 +177,10 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
         }]
       : [];
 
-    const variantBase = selectedVariant?.image?.url.split("?")[0];
     const official: GalleryImage[] =
       (product.images?.edges || [])
-        .filter(({ node }) => node.url.split("?")[0] !== variantBase)
+        .filter(({ node }) => !variantImages.has(node.url.split("?")[0]))
+        .slice(0, 1)
         .map(({ node }) => ({
           url: node.url,
           width: node.width,
@@ -200,7 +206,7 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
       seen.add(base);
       return true;
     });
-  }, [product.images, product.title, ugcItems, selectedVariant?.image, selectedVariant?.image?.url]);
+  }, [product.images, product.title, ugcItems, selectedVariant?.image, variantEdges]);
 
   const isSoldOut =
     !selectedVariant?.availableForSale ||


### PR DESCRIPTION
## Summary
- Build set of variant image URLs to detect duplicates
- Keep only the first non-variant product image in the gallery
- Preserve existing deduplication order of variant, official, and UGC images

## Testing
- `yarn lint` *(fails: React Hook "useAccountValidationContext" is called conditionally, and numerous `@typescript-eslint/no-explicit-any` errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b880bbd1d883289cc9d5a3203a0e57