### PR TITLE
Render thumbnails for main and UGC images

### DIFF
--- a/src/components/ProductGallery.tsx
+++ b/src/components/ProductGallery.tsx
@@ -69,31 +69,36 @@ export default function ProductGallery({ images }: { images: GalleryImage[] }) {
                 role="group" /* simpler ARIA; avoids tablist requirements */
                 aria-label="Product thumbnails"
               >
-                {/* Skip the main image; thumbnails start from second image */}
-                {safeImages.slice(1).map((img, i) => (
-                  <button
-                    key={img.url + (i + 1)}
-                    aria-label={`Show image ${i + 2}`}
-                    className={`thumb ${i + 1 === active ? "is-active" : ""}`}
-                    onClick={() => setActive(i + 1)}
-                    type="button"
-                  >
-                    <div className="thumb-frame">
-                      {/* No labels on thumbnails */}
-                      <Image
-                        src={img.url}
-                        alt=""
-                        width={60}
-                        height={75}
-                        loading="lazy"
-                        decoding="async"
-                        fetchPriority="low"
-                        sizes="60px"
-                        quality={40}
-                      />
-                    </div>
-                  </button>
-                ))}
+                {/* Only show thumbnails for the main image and UGC images */}
+                {safeImages.map((img, i) => {
+                  if (i === 0 || img.isUGC) {
+                    return (
+                      <button
+                        key={img.url + i}
+                        aria-label={`Show image ${i + 1}`}
+                        className={`thumb ${i === active ? "is-active" : ""}`}
+                        onClick={() => setActive(i)}
+                        type="button"
+                      >
+                        <div className="thumb-frame">
+                          {/* No labels on thumbnails */}
+                          <Image
+                            src={img.url}
+                            alt=""
+                            width={60}
+                            height={75}
+                            loading="lazy"
+                            decoding="async"
+                            fetchPriority="low"
+                            sizes="60px"
+                            quality={40}
+                          />
+                        </div>
+                      </button>
+                    );
+                  }
+                  return null;
+                })}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- show thumbnail for the primary image and any UGC images
- use original image index when switching active image

## Testing
- `yarn test` *(fails: Command "test" not found)*
- `yarn lint` *(fails: React Hook "useAccountValidationContext" is called conditionally. React Hooks must be called in the exact same order in every component render.)*


------
https://chatgpt.com/codex/tasks/task_e_68b9351c13c483289e75a6c07586167a