### PR TITLE
feat: support custom default image in gallery

### DIFF
--- a/src/components/ProductGallery.tsx
+++ b/src/components/ProductGallery.tsx
@@ -24,11 +24,17 @@ function useIsDesktop() {
   return isDesktop;
 }
 
-export default function ProductGallery({ images }: { images: GalleryImage[] }) {
-  const [active, setActive] = useState(0);
+export default function ProductGallery({
+  images,
+  defaultActive = 0,
+}: {
+  images: GalleryImage[];
+  defaultActive?: number;
+}) {
+  const [active, setActive] = useState(defaultActive);
   const isDesktop = useIsDesktop();
 
-  useEffect(() => setActive(0), [images]);
+  useEffect(() => setActive(defaultActive), [images, defaultActive]);
 
   const safeImages = useMemo(() => (images || []).filter(Boolean), [images]);
   if (!safeImages.length) return null;

--- a/src/pages/product/[handle].tsx
+++ b/src/pages/product/[handle].tsx
@@ -375,7 +375,10 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
       <main style={{ maxWidth: '1400px', margin: '0 auto', padding: '16px' }}>
         <div className="product-layout">
           <div className="product-image" style={{ position: 'relative' }}>
-            <ProductGallery images={galleryImages} />
+            <ProductGallery
+              images={galleryImages}
+              defaultActive={showVariantImage ? 1 : 0}
+            />
 
             <div className="fav-wrapper">
               {showFav ? (


### PR DESCRIPTION
## Summary
- allow `ProductGallery` to take a `defaultActive` prop to control initial image
- display selected variant image as main by default on product page

## Testing
- `yarn lint` *(fails: React Hook and type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b93522ed608328af2a55cd36e038af