### PR TITLE
Reset variant image when switching to variants without images

### DIFF
--- a/src/pages/product/[handle].tsx
+++ b/src/pages/product/[handle].tsx
@@ -148,10 +148,13 @@ const approved: true | false | null = loading ? null : Boolean(user?.approved);
   }, [user, refreshUser]);
 
   useEffect(() => {
-  const v = variantEdges.find(e => e.node.id === selectedVariantId)?.node;
-  if (!v) return;
-  setQty((v.quantityAvailable ?? 0) > 0 ? 1 : 0);
-}, [selectedVariantId, variantEdges]);
+    const v = variantEdges.find(e => e.node.id === selectedVariantId)?.node;
+    if (!v) return;
+    setQty((v.quantityAvailable ?? 0) > 0 ? 1 : 0);
+    if (!v.image) {
+      setShowVariantImage(false);
+    }
+  }, [selectedVariantId, variantEdges]);
 
 
   const selectedVariant = product?.variants?.edges?.find(


### PR DESCRIPTION
## Summary
- clear variant image display when selecting a variant lacking a custom image to avoid stale gallery images

## Testing
- `yarn lint --file src/pages/product/[handle].tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b93524e4b0832899b220a685860cf7