### PR TITLE
Align UGC heading width with product gallery

### DIFF
--- a/src/components/StyledByYou.tsx
+++ b/src/components/StyledByYou.tsx
@@ -23,7 +23,7 @@ export default function StyledByYou({
 
   return (
     <section aria-label="Styled by you" className="ugc">
-      <h2>STYLED BY YOU</h2>
+      <h2 className="ugc-title">STYLED BY YOU</h2>
       <p>Upload your photo for a chance to be featured.</p>
       <a
         className="ugc-upload-btn"

--- a/src/styles/pages/product.scss
+++ b/src/styles/pages/product.scss
@@ -150,10 +150,12 @@ input[type='number'] {
 .ugc {
   margin-top: 24px;
 
-  h2 {
+  .ugc-title {
     margin: 0 0 12px;
     font-size: 16px;
     font-weight: 600;
+    width: 100%;
+    max-width: 100%;
   }
   p {
         margin: 0 0 12px;
@@ -225,6 +227,11 @@ input[type='number'] {
     .ugc-grid {
       grid-template-columns: repeat(5, 1fr);
       gap: 12px;
+    }
+
+    .ugc-title {
+      max-width: calc((min(1400px, 100vw) - 32px - 24px) / 2);
+      margin-left: 0;
     }
   }
 }


### PR DESCRIPTION
## Summary
- scope UGC heading with a dedicated class
- constrain UGC title width to mirror product gallery on desktop while remaining full-width on mobile

## Testing
- `npm run lint` *(fails: React Hook "useAccountValidationContext" is called conditionally)*
- `npm run build` *(fails: Error generating sitemap: Shopify fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b973dee36c83288d7f4590493f746c