### PR TITLE
Fix search query router.replace path

### DIFF
--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -66,14 +66,9 @@ export default function SearchPage() {
     setLoading(true);
     setQuery(value);
 
-    router.replace(
-      {
-        pathname: '/search',
-        query: value ? { q: value } : {},
-      },
-      undefined,
-      { shallow: true }
-    );
+    router.replace(`/search${value ? `?q=${encodeURIComponent(value)}` : ''}`, undefined, {
+      shallow: true,
+    });
   };
 
   return (


### PR DESCRIPTION
## Summary
- update the search page input handler to use an absolute `/search` path when replacing the router state
- ensure the query string is properly URL encoded before updating the shallow route

## Testing
- yarn lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c92d8941b48328a8a418895191e823