### PR TITLE
Unregister PWA service worker before redirecting to Shopify checkout

### DIFF
--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -165,6 +165,18 @@ export default function CartDrawer() {
                   });
                 }
               });
+
+              // The PWA service worker interferes with Shopify's checkout pages
+              // (they live on the same origin), leaving the checkout stuck in a
+              // skeleton state. Remove active registrations before redirecting.
+              if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
+                try {
+                  const registrations = await navigator.serviceWorker.getRegistrations();
+                  await Promise.all(registrations.map((registration) => registration.unregister()));
+                } catch (err) {
+                  console.error('Failed to unregister service workers before checkout:', err);
+                }
+              }
               window.location.href = url;
             }}
           >


### PR DESCRIPTION
## Summary
- prevent the Next.js PWA service worker from hijacking Shopify checkout requests by unregistering it just before redirecting
- add defensive logging so failures to unregister don't block checkout navigation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4e17417808328b18ba547c5a0e9f9